### PR TITLE
Update literal.ts

### DIFF
--- a/src/types/core/literal.ts
+++ b/src/types/core/literal.ts
@@ -22,7 +22,6 @@ type SpecialCharacters =
   | "*"
   | "("
   | ")"
-  | "-"
   | "_"
   | "+"
   | "="


### PR DESCRIPTION
As per documentation https://discord.com/developers/docs/interactions/application-commands the character: "-" is actually allowed in names.

At least been using it that way for ages and documentation also says that this is the case. It should verify the regex: "^[\w-]{1,32}$" so any word characters or a dash

## The changes this PR makes?

## Why it should be merged?
