### PR TITLE
chore(logger): allow pass custom logger to client instance

### DIFF
--- a/src/types/core/ClientOptions.ts
+++ b/src/types/core/ClientOptions.ts
@@ -5,6 +5,7 @@ import {
   SimpleCommandMessage,
 } from "../..";
 import { ClientOptions as DiscordJSClientOptions, Message } from "discord.js";
+import { ILogger } from "..";
 
 export interface SimpleCommandConfig {
   /**
@@ -47,7 +48,7 @@ export interface ClientOptions extends DiscordJSClientOptions {
   simpleCommand?: SimpleCommandConfig;
 
   /**
-   * Do not log anything in the console
+   * Do not log anything
    */
   silent?: boolean;
 
@@ -65,4 +66,9 @@ export interface ClientOptions extends DiscordJSClientOptions {
    * Set the guilds globally for application commands
    */
   botGuilds?: IGuild[];
+
+  /**
+   * Set custom logger implementation
+   */
+  logger?: ILogger;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,3 +11,4 @@ export * from "./public/CommandType";
 export * from "./public/decorators";
 export * from "./public/GuardFunction";
 export * from "./public/interfaces";
+export * from "./util/logger";

--- a/src/types/public/interfaces/InitCommandConfig.ts
+++ b/src/types/public/interfaces/InitCommandConfig.ts
@@ -1,6 +1,6 @@
 export interface InitCommandConfig {
   /**
-   * Enable console log
+   * Enable logging
    */
   log?: boolean;
   /**

--- a/src/types/util/logger.ts
+++ b/src/types/util/logger.ts
@@ -1,0 +1,4 @@
+export interface ILogger {
+  log(...args: unknown[]): void;
+  error(...args: unknown[]): void;
+}


### PR DESCRIPTION
## The changes this PR makes?

Adding logger to the client instance

## Why it should be merged?

Will allow users use custom loggers dependet on their need. For example write to files, use custom prefixes for logs, coloring, e.t.c