### PR TITLE
Fix GuardDatas Incorrect Example

### DIFF
--- a/docs/docs/decorators/general/guard.md
+++ b/docs/docs/decorators/general/guard.md
@@ -153,7 +153,7 @@ import { ArgsOf, GuardFunction } from "discordx";
 export const NotBot: GuardFunction<
   | ArgsOf<"messageCreate" | "messageReactionAdd" | "voiceStateUpdate">
   | CommandInteraction
-> = async (arg, client, next) => {
+> = async (arg, client, next, guardDatas) => {
   const argObj = arg instanceof Array ? arg[0] : arg;
   const user =
     argObj instanceof CommandInteraction
@@ -164,6 +164,7 @@ export const NotBot: GuardFunction<
       ? argObj.member.user
       : argObj.author;
   if (!user?.bot) {
+    guardDatas.message = "the NotBot guard passed";
     await next();
   }
 };

--- a/docs/docs/decorators/general/guard.md
+++ b/docs/docs/decorators/general/guard.md
@@ -182,7 +182,7 @@ abstract class AppDiscord {
   async hello(
     interaction: CommandInteraction,
     client: Client,
-    guardDatas: any
+    guardDatas: { message: string }
   ) {
     console.log(guardDatas.message);
     // > the NotBot guard passed


### PR DESCRIPTION
## The changes this PR makes?
Guard Functions documentation has incorrect example of  `GuardDatas` usage. It don't use `guardDatas` variable at all!

This PR corrects documentation by adding missing code from [old DiscordTS Docs](https://owencalvin.github.io/discord.ts/decorators/guard.html#guard-datas)

## Why it should be merged?
Incorrect examples in documentation confuses developers