### PR TITLE
Fix CommonJS builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "npm run build:esm && npm run build:cjs && npm run build:fixup",
     "build:esm": "tsc",
-    "build:cjs": "tsc --outDir build/cjs",
+    "build:cjs": "tsc --project tsconfig.cjs.json",
     "build:fixup": "node scripts/fixup.mjs",
     "build:changelog": "node scripts/changelog.mjs",
     "format": "prettier --write .",

--- a/packages/music/package.json
+++ b/packages/music/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "npm run build:esm && npm run build:cjs && npm run build:fixup",
     "build:esm": "tsc",
-    "build:cjs": "tsc --outDir build/cjs",
+    "build:cjs": "tsc --project tsconfig.cjs.json",
     "build:fixup": "node ../../scripts/fixup-music.mjs",
     "type-check": "tsc --noemit"
   },

--- a/packages/music/tsconfig.cjs.json
+++ b/packages/music/tsconfig.cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "build/cjs",
+    "module": "CommonJS",
+    "target": "ES2021"
+  }
+}

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "npm run build:esm && npm run build:cjs && npm run build:fixup",
     "build:esm": "tsc",
-    "build:cjs": "tsc --outDir build/cjs",
+    "build:cjs": "tsc --project tsconfig.cjs.json",
     "build:fixup": "node ../../scripts/fixup-utilities.mjs",
     "type-check": "tsc --noemit"
   },

--- a/packages/utilities/tsconfig.cjs.json
+++ b/packages/utilities/tsconfig.cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "build/cjs",
+    "module": "CommonJS",
+    "target": "ES2021"
+  }
+}

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "build/cjs",
+    "module": "CommonJS",
+    "target": "ES2021"
+  }
+}


### PR DESCRIPTION
You have separate CommonJS and EMS builds, but the CommonJS builds aren't CommonJS and cannot be used by CommonJS code.

Steps to reproduce:

```js
const discordx = require("discordx");
```

if you run this on straight Node (tested on Gallium), it will fail:

```
$ node index.js
/projects/temp/node_modules/discordx/build/cjs/index.js:1
import "reflect-metadata";
^^^^^^

SyntaxError: Cannot use import statement outside a module
    at Object.compileFunction (node:vm:352:18)
    at wrapSafe (node:internal/modules/cjs/loader:1031:15)
    at Module._compile (node:internal/modules/cjs/loader:1065:27)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/projects/temp/index.js:1:18)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
```

This changes the typescript compiler to output valid CommonJS so that it will work out of the box with CommonJS apps/pipelines downstream.

## Packages

- discordx
- @discordx/music
- @discordx/utilities
