### PR TITLE
feat: add apple music support for @discordx/music

### DIFF
--- a/packages/music/package.json
+++ b/packages/music/package.json
@@ -51,6 +51,7 @@
   "dependencies": {
     "@types/backoff": "^2.5.2",
     "ansi-regex": "^6.0.1",
+    "apple-music-metadata": "^1.0.10",
     "backoff": "^2.5.0",
     "ffmpeg-static": "^4.4.1",
     "libsodium-wrappers": "^0.7.9",

--- a/packages/music/src/YoutubePlayer/core/Queue.ts
+++ b/packages/music/src/YoutubePlayer/core/Queue.ts
@@ -641,7 +641,7 @@ export abstract class Queue<T extends Player = Player> {
   }
 
   /**
-   * Play apple links
+   * Play apple music links
    * @param search
    * @param options
    * @param enqueueTop

--- a/packages/music/src/YoutubePlayer/core/Queue.ts
+++ b/packages/music/src/YoutubePlayer/core/Queue.ts
@@ -530,7 +530,7 @@ export abstract class Queue<T extends Player = Player> {
   }
 
   /**
-   * play custom track
+   * Play custom track
    * @param track
    * @param options
    * @returns
@@ -552,7 +552,7 @@ export abstract class Queue<T extends Player = Player> {
   }
 
   /**
-   * play song
+   * Play youtube song
    * @param search
    * @param options
    * @param enqueueTop
@@ -581,7 +581,7 @@ export abstract class Queue<T extends Player = Player> {
   }
 
   /**
-   * play playlist
+   * Play youtube playlist
    * @param search
    * @param options
    * @param enqueueTop
@@ -656,6 +656,7 @@ export abstract class Queue<T extends Player = Player> {
     if (!appleTracks) {
       return;
     }
+
     let allVideos: (Video | undefined)[] = [];
     if (appleTracks.type === "song") {
       const song = await Util.getSong(
@@ -672,10 +673,12 @@ export abstract class Queue<T extends Player = Player> {
         )
       );
     }
+
     const videos = _.compact(allVideos);
     const tracks = videos.map(
       (video) => new YoutubeTrack(video, this.player, options)
     );
+
     this.enqueue(tracks, enqueueTop);
     this.processQueue();
     return tracks;

--- a/packages/music/src/YoutubePlayer/core/Queue.ts
+++ b/packages/music/src/YoutubePlayer/core/Queue.ts
@@ -652,8 +652,7 @@ export abstract class Queue<T extends Player = Player> {
     options?: ITrackOptions,
     enqueueTop?: boolean
   ): Promise<YoutubeTrack[] | undefined> {
-    const appleTracks =
-      typeof search === "string" ? await Util.getAppleTracks(search) : search;
+    const appleTracks = await Util.getAppleTracks(search);
     if (!appleTracks) {
       return;
     }
@@ -663,8 +662,10 @@ export abstract class Queue<T extends Player = Player> {
         appleTracks.title + " - " + appleTracks.artist
       );
       allVideos = [song];
-    }
-    if (appleTracks.type === "playlist" || appleTracks.type === "album") {
+    } else if (
+      appleTracks.type === "playlist" ||
+      appleTracks.type === "album"
+    ) {
       allVideos = await Promise.all(
         appleTracks.tracks.map((sr) =>
           Util.getSong(sr.title + " - " + sr.artist)

--- a/packages/music/src/YoutubePlayer/core/Queue.ts
+++ b/packages/music/src/YoutubePlayer/core/Queue.ts
@@ -641,7 +641,7 @@ export abstract class Queue<T extends Player = Player> {
   }
 
   /**
-   * Play apple
+   * Play apple links
    * @param search
    * @param options
    * @param enqueueTop

--- a/packages/music/src/YoutubePlayer/core/Queue.ts
+++ b/packages/music/src/YoutubePlayer/core/Queue.ts
@@ -639,4 +639,51 @@ export abstract class Queue<T extends Player = Player> {
     this.processQueue();
     return tracks;
   }
+  
+  /**
+   * Play apple
+   * @param search
+   * @param options
+   * @param enqueueTop
+   * @returns
+   */
+   public async apple(
+    search: string,
+    options?: ITrackOptions,
+    enqueueTop?: boolean
+  ): Promise<YoutubeTrack[] | undefined> {
+    const appleTracks =
+      typeof search === "string" ? await Util.getAppleTracks(search) : search;
+    if (!appleTracks) {
+      return;
+    }
+    let allVideos: (Video | undefined)[] = [];
+    if (appleTracks.type === "song") {
+        const song = await Util.getSong(
+            appleTracks.title +
+            " - " +
+            appleTracks.artist
+        );
+        allVideos = [song];
+    };
+    if (appleTracks.type === 'playlist' || appleTracks.type === 'album') {
+
+        allVideos = await Promise.all(
+            appleTracks.tracks.map((sr) =>
+            Util.getSong(
+              sr.title +
+                " - " +
+                sr.artist
+            )
+          )
+        );
+    }
+    const videos = _.compact(allVideos);
+    const tracks = videos.map(
+      (video) => new YoutubeTrack(video, this.player, options)
+    );
+    this.enqueue(tracks, enqueueTop);
+    this.processQueue();
+    return tracks;
+  }
 }

--- a/packages/music/src/YoutubePlayer/core/Queue.ts
+++ b/packages/music/src/YoutubePlayer/core/Queue.ts
@@ -639,7 +639,7 @@ export abstract class Queue<T extends Player = Player> {
     this.processQueue();
     return tracks;
   }
-  
+
   /**
    * Play apple
    * @param search
@@ -647,7 +647,7 @@ export abstract class Queue<T extends Player = Player> {
    * @param enqueueTop
    * @returns
    */
-   public async apple(
+  public async apple(
     search: string,
     options?: ITrackOptions,
     enqueueTop?: boolean
@@ -659,24 +659,17 @@ export abstract class Queue<T extends Player = Player> {
     }
     let allVideos: (Video | undefined)[] = [];
     if (appleTracks.type === "song") {
-        const song = await Util.getSong(
-            appleTracks.title +
-            " - " +
-            appleTracks.artist
-        );
-        allVideos = [song];
-    };
-    if (appleTracks.type === 'playlist' || appleTracks.type === 'album') {
-
-        allVideos = await Promise.all(
-            appleTracks.tracks.map((sr) =>
-            Util.getSong(
-              sr.title +
-                " - " +
-                sr.artist
-            )
-          )
-        );
+      const song = await Util.getSong(
+        appleTracks.title + " - " + appleTracks.artist
+      );
+      allVideos = [song];
+    }
+    if (appleTracks.type === "playlist" || appleTracks.type === "album") {
+      allVideos = await Promise.all(
+        appleTracks.tracks.map((sr) =>
+          Util.getSong(sr.title + " - " + sr.artist)
+        )
+      );
     }
     const videos = _.compact(allVideos);
     const tracks = videos.map(

--- a/packages/music/src/YoutubePlayer/logic/util.ts
+++ b/packages/music/src/YoutubePlayer/logic/util.ts
@@ -1,12 +1,12 @@
+import {
+  RawApplePlaylist,
+  RawAppleSong,
+  autoGetApple,
+} from "apple-music-metadata";
 import _ from "lodash";
 import spotify from "spotify-url-info";
 import ytpl from "ytpl";
 import ytsr from "ytsr";
-import {
-  autoGetApple,
-  RawApplePlaylist,
-  RawAppleSong,
-} from "apple-music-metadata";
 
 export class Util {
   /**
@@ -112,7 +112,7 @@ export class Util {
   }
 
   /**
-   * Get spotify tracks by url
+   * Get apple tracks by url
    * @param url
    * @returns
    */

--- a/packages/music/src/YoutubePlayer/logic/util.ts
+++ b/packages/music/src/YoutubePlayer/logic/util.ts
@@ -2,7 +2,11 @@ import _ from "lodash";
 import spotify from "spotify-url-info";
 import ytpl from "ytpl";
 import ytsr from "ytsr";
-import { autoGetApple, RawApplePlaylist, RawAppleSong } from "apple-music-metadata"
+import {
+  autoGetApple,
+  RawApplePlaylist,
+  RawAppleSong,
+} from "apple-music-metadata";
 
 export class Util {
   /**
@@ -106,19 +110,19 @@ export class Util {
       return undefined;
     }
   }
-  
+
   /**
    * Get spotify tracks by url
    * @param url
    * @returns
    */
-   static async getAppleTracks(
+  static async getAppleTracks(
     url: string
-  ): Promise<RawApplePlaylist|RawAppleSong|undefined>{
+  ): Promise<RawApplePlaylist | RawAppleSong | undefined> {
     try {
-        return await autoGetApple(url);
-      } catch (err) {
-        return undefined;
-      }
+      return await autoGetApple(url);
+    } catch (err) {
+      return undefined;
+    }
   }
 }

--- a/packages/music/src/YoutubePlayer/logic/util.ts
+++ b/packages/music/src/YoutubePlayer/logic/util.ts
@@ -2,6 +2,7 @@ import _ from "lodash";
 import spotify from "spotify-url-info";
 import ytpl from "ytpl";
 import ytsr from "ytsr";
+import { autoGetApple, RawApplePlaylist, RawAppleSong } from "apple-music-metadata"
 
 export class Util {
   /**
@@ -104,5 +105,20 @@ export class Util {
     } catch (err) {
       return undefined;
     }
+  }
+  
+  /**
+   * Get spotify tracks by url
+   * @param url
+   * @returns
+   */
+   static async getAppleTracks(
+    url: string
+  ): Promise<RawApplePlaylist|RawAppleSong|undefined>{
+    try {
+        return await autoGetApple(url);
+      } catch (err) {
+        return undefined;
+      }
   }
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Adds support for apple music links when using the music player.
Made to be as similar as possible to the spotify usage and code. 

Sorry took ages to redo as have been very busy.
## Package
- @discordx/music
<!--
Lines that apply to you should be moved out of the comment
- discordx
- @discordx/utilities
-->
