### PR TITLE
fix: .setVolume() not working in custom tracks

### DIFF
--- a/packages/music/src/YoutubePlayer/tracks/CustomTrack.ts
+++ b/packages/music/src/YoutubePlayer/tracks/CustomTrack.ts
@@ -31,6 +31,7 @@ export class CustomTrack extends Track {
   public createAudioResource(): AudioResource<CommonTrack> {
     return createAudioResource(this.source, {
       inputType: this.streamType,
+      inlineVolume: true,
       metadata: this,
     });
   }

--- a/packages/music/src/YoutubePlayer/tracks/CustomTrack.ts
+++ b/packages/music/src/YoutubePlayer/tracks/CustomTrack.ts
@@ -30,8 +30,8 @@ export class CustomTrack extends Track {
    */
   public createAudioResource(): AudioResource<CommonTrack> {
     return createAudioResource(this.source, {
-      inputType: this.streamType,
       inlineVolume: true,
+      inputType: this.streamType,
       metadata: this,
     });
   }


### PR DESCRIPTION
enable inlineVolume in createAudioResource so that `.setVolume` works

## Package

- @discordx/music
