### PR TITLE
Correct parameter types to prevent invalid TypeError

### DIFF
--- a/packages/discordx/src/types/core/ClientOptions.ts
+++ b/packages/discordx/src/types/core/ClientOptions.ts
@@ -64,7 +64,7 @@ export interface ClientOptions extends DiscordJSClientOptions {
   /**
    * Do not log anything
    */
-  silent?: false;
+  silent?: boolean;
 
   /**
    * simple command related customization

--- a/packages/discordx/src/types/public/slash.ts
+++ b/packages/discordx/src/types/public/slash.ts
@@ -16,7 +16,7 @@ export type ApplicationCommandParams = {
 
 export type SlashOptionBase = {
   description?: string;
-  required?: false;
+  required?: boolean;
 };
 
 export type SlashOptionBaseParams = SlashOptionBase & {


### PR DESCRIPTION
Types for ``SlashOptionBase.required`` and ``ClientOptions.silent`` are of type ``false`` instead of ``boolean``. This does not allow a value of ``true`` to be set.

**Please describe the changes this PR makes and why it should be merged:**
- Changed parameter types for ``SlashOptionBase.required`` and ``ClientOptions.silent`` from ``false`` to ``boolean``.
    - Being set both to ``false`` would not allow a value of ``true`` to be assigned throwing a TypeError.

## Package
- discordx