### PR TITLE
chore(discordx): fix broken links in readme

### DIFF
--- a/packages/discordx/README.md
+++ b/packages/discordx/README.md
@@ -126,9 +126,9 @@ There is a whole system that allows you to implement complex slash/simple comman
 ## Commands
 
 - [`@Slash`](https://discord-ts.js.org/docs/decorators/commands/slash)
-- [`@SlashChoice`](https://discord-ts.js.org/docs/decorators/commands/slashchoice)
-- [`@SlashGroup`](https://discord-ts.js.org/docs/decorators/commands/slashgroup)
-- [`@SlashOption`](https://discord-ts.js.org/docs/decorators/commands/slashoption)
+- [`@SlashChoice`](https://discord-ts.js.org/docs/decorators/commands/slash-choice)
+- [`@SlashGroup`](https://discord-ts.js.org/docs/decorators/commands/slash-group)
+- [`@SlashOption`](https://discord-ts.js.org/docs/decorators/commands/slash-option)
 - [`@SimpleCommand`](https://discord-ts.js.org/docs/decorators/commands/simple-command)
 - [`@SimpleCommandOption`](https://discord-ts.js.org/docs/decorators/commands/simple-command-option)
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Just a couple of broken documentation links

## Package
- discordx

<!--
Lines that apply to you should be moved out of the comment
- @discordx/music
- @discordx/utilities
-->
