### PR TITLE
refactor: create PermissionGuardType + allow embeds as custom reply

### DIFF
--- a/packages/utilities/README.md
+++ b/packages/utilities/README.md
@@ -189,7 +189,7 @@ This will work on both Slash and Simple commands
 
 When you are using global commands, but still wish to restrict commands to permissions from roles, then you can use this guard to easily supply an array of Permissions that a user must have in order to execute the command.
 
-The guard can take an array of permissions or an async resolver to the permission array and a PermissionGuardOptions object with `content` and `ephemeral` values.
+Permission guards can take an array of permissions or an async resolver to the permission array, as well as a PermissionGuardOptions object that contains `content` and `ephemeral` values.
 
 ### Example
 

--- a/packages/utilities/README.md
+++ b/packages/utilities/README.md
@@ -247,6 +247,26 @@ export class PermissionGuards {
     }
     return Promise.resolve(["BAN_MEMBERS"]);
   }
+  
+  /**
+   * Only allow users with the role "BAN_MEMBERS" with a custom embed
+   *
+   * @param interaction
+   */
+  @Slash("permission_ban_members")
+  @Guard(
+    PermissionGuard(["BAN_MEMBERS"], PermissionGuards.genEmbed())
+  )
+  banMembers4(interaction: CommandInteraction): void {
+    interaction.reply("It worked!");
+  }
+
+  private static genEmbed() {
+    let embed = new MessageEmbed()
+    .setColor("RED")
+    .setDescription("You do not have the role `BAN_MEMBERS`");
+    return embed;
+  }
 }
 ```
 

--- a/packages/utilities/README.md
+++ b/packages/utilities/README.md
@@ -254,7 +254,11 @@ export class PermissionGuards {
    * @param interaction
    */
   @Slash("permission_ban_members")
-  @Guard(PermissionGuard(["BAN_MEMBERS"], PermissionGuards.genEmbed()))
+  @Guard(
+    PermissionGuard(["BAN_MEMBERS"], {
+      content: PermissionGuards.genEmbed(),
+    })
+  )
   banMembers4(interaction: CommandInteraction): void {
     interaction.reply("It worked!");
   }

--- a/packages/utilities/README.md
+++ b/packages/utilities/README.md
@@ -189,7 +189,7 @@ This will work on both Slash and Simple commands
 
 When you are using global commands, but still wish to restrict commands to permissions from roles, then you can use this guard to easily supply an array of Permissions that a user must have in order to execute the command.
 
-The guard can take an array of permissions or an async resolver to the permission array
+The guard can take an array of permissions or an async resolver to the permission array and a PermissionGuardOptions object with `content` and `ephemeral` values.
 
 ### Example
 
@@ -214,7 +214,9 @@ export class PermissionGuards {
    */
   @Slash("permission_ban_members")
   @Guard(
-    PermissionGuard(["BAN_MEMBERS"], "You do not have the role `BAN_MEMBERS`")
+    PermissionGuard(["BAN_MEMBERS"], {
+      content: "You do not have the role `BAN_MEMBERS`",
+    })
   )
   banMembers2(interaction: CommandInteraction): void {
     interaction.reply("It worked!");
@@ -227,10 +229,9 @@ export class PermissionGuards {
    */
   @Slash("permission_ban_members")
   @Guard(
-    PermissionGuard(
-      PermissionGuards.resolvePermission,
-      "You do not have the role `BAN_MEMBERS`"
-    )
+    PermissionGuard(PermissionGuards.resolvePermission, {
+      content: "You do not have the role `BAN_MEMBERS`",
+    })
   )
   banMembers3(interaction: CommandInteraction): void {
     interaction.reply("It worked!");
@@ -264,10 +265,9 @@ export class PermissionGuards {
   }
 
   private static genEmbed() {
-    let embed = new MessageEmbed()
+    return new MessageEmbed()
       .setColor("RED")
       .setDescription("You do not have the role `BAN_MEMBERS`");
-    return embed;
   }
 }
 ```

--- a/packages/utilities/README.md
+++ b/packages/utilities/README.md
@@ -247,24 +247,22 @@ export class PermissionGuards {
     }
     return Promise.resolve(["BAN_MEMBERS"]);
   }
-  
+
   /**
    * Only allow users with the role "BAN_MEMBERS" with a custom embed
    *
    * @param interaction
    */
   @Slash("permission_ban_members")
-  @Guard(
-    PermissionGuard(["BAN_MEMBERS"], PermissionGuards.genEmbed())
-  )
+  @Guard(PermissionGuard(["BAN_MEMBERS"], PermissionGuards.genEmbed()))
   banMembers4(interaction: CommandInteraction): void {
     interaction.reply("It worked!");
   }
 
   private static genEmbed() {
     let embed = new MessageEmbed()
-    .setColor("RED")
-    .setDescription("You do not have the role `BAN_MEMBERS`");
+      .setColor("RED")
+      .setDescription("You do not have the role `BAN_MEMBERS`");
     return embed;
   }
 }

--- a/packages/utilities/examples/guards/commands/PermissionGuards.ts
+++ b/packages/utilities/examples/guards/commands/PermissionGuards.ts
@@ -1,5 +1,5 @@
 import type { PermissionString } from "discord.js";
-import { CommandInteraction } from "discord.js";
+import { CommandInteraction, MessageEmbed } from 'discord.js';
 import { Discord, Guard, Slash } from "discordx";
 
 import type { PermissionHandlerInteraction } from "../../../src/index.js";
@@ -57,5 +57,27 @@ export class PermissionGuards {
       }
     }
     return Promise.resolve(["BAN_MEMBERS"]);
+  }
+
+  /**
+   * Only allow users with the role "BAN_MEMBERS" with a custom embed
+   *
+   * @param interaction
+   */
+
+  
+  @Slash("permission_ban_members")
+  @Guard(
+    PermissionGuard(["BAN_MEMBERS"], PermissionGuards.genEmbed())
+  )
+  banMembers4(interaction: CommandInteraction): void {
+    interaction.reply("It worked!");
+  }
+
+  private static genEmbed() {
+    let embed = new MessageEmbed()
+    .setColor("RED")
+    .setDescription("You do not have the role `BAN_MEMBERS`");
+    return embed;
   }
 }

--- a/packages/utilities/examples/guards/commands/PermissionGuards.ts
+++ b/packages/utilities/examples/guards/commands/PermissionGuards.ts
@@ -25,7 +25,9 @@ export class PermissionGuards {
    */
   @Slash("permission_ban_members")
   @Guard(
-    PermissionGuard(["BAN_MEMBERS"], "You do not have the role `BAN_MEMBERS`")
+    PermissionGuard(["BAN_MEMBERS"], {
+      content: "You do not have the role `BAN_MEMBERS`",
+    })
   )
   banMembers2(interaction: CommandInteraction): void {
     interaction.reply("It worked!");
@@ -38,10 +40,9 @@ export class PermissionGuards {
    */
   @Slash("permission_ban_members")
   @Guard(
-    PermissionGuard(
-      PermissionGuards.resolvePermission,
-      "You do not have the role `BAN_MEMBERS`"
-    )
+    PermissionGuard(PermissionGuards.resolvePermission, {
+      content: "You do not have the role `BAN_MEMBERS`",
+    })
   )
   banMembers3(interaction: CommandInteraction): void {
     interaction.reply("It worked!");
@@ -66,7 +67,11 @@ export class PermissionGuards {
    */
 
   @Slash("permission_ban_members")
-  @Guard(PermissionGuard(["BAN_MEMBERS"], PermissionGuards.genEmbed()))
+  @Guard(
+    PermissionGuard(["BAN_MEMBERS"], {
+      content: PermissionGuards.genEmbed(),
+    })
+  )
   banMembers4(interaction: CommandInteraction): void {
     interaction.reply("It worked!");
   }

--- a/packages/utilities/examples/guards/commands/PermissionGuards.ts
+++ b/packages/utilities/examples/guards/commands/PermissionGuards.ts
@@ -1,5 +1,5 @@
 import type { PermissionString } from "discord.js";
-import { CommandInteraction, MessageEmbed } from 'discord.js';
+import { CommandInteraction, MessageEmbed } from "discord.js";
 import { Discord, Guard, Slash } from "discordx";
 
 import type { PermissionHandlerInteraction } from "../../../src/index.js";
@@ -65,19 +65,15 @@ export class PermissionGuards {
    * @param interaction
    */
 
-  
   @Slash("permission_ban_members")
-  @Guard(
-    PermissionGuard(["BAN_MEMBERS"], PermissionGuards.genEmbed())
-  )
+  @Guard(PermissionGuard(["BAN_MEMBERS"], PermissionGuards.genEmbed()))
   banMembers4(interaction: CommandInteraction): void {
     interaction.reply("It worked!");
   }
 
   private static genEmbed() {
-    let embed = new MessageEmbed()
-    .setColor("RED")
-    .setDescription("You do not have the role `BAN_MEMBERS`");
-    return embed;
+    return new MessageEmbed()
+      .setColor("RED")
+      .setDescription("You do not have the role `BAN_MEMBERS`");
   }
 }

--- a/packages/utilities/src/guards/PermissionGuard/PermissionGuard.ts
+++ b/packages/utilities/src/guards/PermissionGuard/PermissionGuard.ts
@@ -13,13 +13,12 @@ import { SimpleCommandMessage } from "discordx";
 import type {
   PermissionGuardOptions,
   PermissionHandlerInteraction,
-  PermissionReplyOptions,
 } from "./types";
 
 /**
  * Set an array of permissions that this command is allowed to use, this is useful for global commands that can not use the `@Permission` decorator, until Permissions 2v is out
  * @param permissions - an array of Permissions or a function to resolve the permissions
- * @param options - Options for the guard repl. Available options are: `content` (string or MessageEmbed) and `ephemeral` (boolean) defaults to `content`: "No permissions" and `ephemeral`: false
+ * @param options - Options for the guard reply. Available options are: `content` (string or MessageEmbed) and `ephemeral` (boolean) defaults to `content`: "No permissions" and `ephemeral`: false
  */
 export function PermissionGuard(
   permissions:
@@ -34,6 +33,12 @@ export function PermissionGuard(
 ): GuardFunction<
   CommandInteraction | SimpleCommandMessage | ContextMenuInteraction
 > {
+  type PermissionReplyOptions = {
+    content?: string;
+    embeds?: MessageEmbed[];
+    ephemeral?: boolean;
+  };
+
   async function replyOrFollowUp(
     interaction: BaseCommandInteraction | MessageComponentInteraction,
     content: PermissionReplyOptions

--- a/packages/utilities/src/guards/PermissionGuard/PermissionGuard.ts
+++ b/packages/utilities/src/guards/PermissionGuard/PermissionGuard.ts
@@ -13,6 +13,7 @@ import { SimpleCommandMessage } from "discordx";
 import type {
   PermissionGuardOptions,
   PermissionHandlerInteraction,
+  PermissionReplyOptions,
 } from "./types";
 
 /**
@@ -32,7 +33,7 @@ export function PermissionGuard(
 > {
   async function replyOrFollowUp(
     interaction: BaseCommandInteraction | MessageComponentInteraction,
-    content: object
+    content: PermissionReplyOptions
   ): Promise<void> {
     if (interaction.replied) {
       await interaction.followUp(content);
@@ -49,7 +50,7 @@ export function PermissionGuard(
 
   async function post(
     arg: BaseCommandInteraction | SimpleCommandMessage,
-    msg: object
+    msg: PermissionReplyOptions
   ): Promise<void> {
     if (arg instanceof SimpleCommandMessage) {
       await arg?.message.reply(msg);
@@ -92,16 +93,14 @@ export function PermissionGuard(
       return next();
     }
 
+    const postOptions: PermissionReplyOptions = {
+      ephemeral: !!options.ephemeral,
+    };
     if (options.content instanceof MessageEmbed) {
-      return post(arg, {
-        embeds: [options.content],
-        ephemeral: options.ephemeral ? true : false,
-      });
+      postOptions["embeds"] = [options.content];
     } else {
-      return post(arg, {
-        content: options.content,
-        ephemeral: options.ephemeral ? true : false,
-      });
+      postOptions["content"] = options.content;
     }
+    return post(arg, postOptions);
   };
 }

--- a/packages/utilities/src/guards/PermissionGuard/PermissionGuard.ts
+++ b/packages/utilities/src/guards/PermissionGuard/PermissionGuard.ts
@@ -19,7 +19,7 @@ import type {
 /**
  * Set an array of permissions that this command is allowed to use, this is useful for global commands that can not use the `@Permission` decorator, until Permissions 2v is out
  * @param permissions - an array of Permissions or a function to resolve the permissions
- * @param messageIfNotAllowed - message to post when the member using this command does not have the correct permissions, defaults to "No permissions"
+ * @param options - Options for the guard repl. Available options are: `content` (string or MessageEmbed) and `ephemeral` (boolean) defaults to `content`: "No permissions" and `ephemeral`: false
  */
 export function PermissionGuard(
   permissions:
@@ -27,7 +27,10 @@ export function PermissionGuard(
     | ((
         interaction: PermissionHandlerInteraction
       ) => Promise<PermissionString[]>),
-  options: PermissionGuardOptions
+  options: PermissionGuardOptions = {
+    content: "No permissions",
+    ephemeral: false,
+  }
 ): GuardFunction<
   CommandInteraction | SimpleCommandMessage | ContextMenuInteraction
 > {

--- a/packages/utilities/src/guards/PermissionGuard/PermissionGuard.ts
+++ b/packages/utilities/src/guards/PermissionGuard/PermissionGuard.ts
@@ -4,13 +4,16 @@ import type {
   ContextMenuInteraction,
   Guild,
   MessageComponentInteraction,
-  PermissionString
+  PermissionString,
 } from "discord.js";
-import { GuildMember, MessageEmbed } from 'discord.js';
+import { GuildMember, MessageEmbed } from "discord.js";
 import type { Client, GuardFunction, Next } from "discordx";
 import { SimpleCommandMessage } from "discordx";
 
-import type { PermissionHandlerInteraction, PermissionGuardOptions } from "./types";
+import type {
+  PermissionGuardOptions,
+  PermissionHandlerInteraction,
+} from "./types";
 
 /**
  * Set an array of permissions that this command is allowed to use, this is useful for global commands that can not use the `@Permission` decorator, until Permissions 2v is out
@@ -62,8 +65,9 @@ export function PermissionGuard(
   ) {
     let guild: Guild | null = null;
     let callee: GuildMember | null = null;
-    if (!options.content)
+    if (!options.content) {
       options.content = "No permissions";
+    }
     if (arg instanceof SimpleCommandMessage) {
       if (arg.message.inGuild()) {
         guild = arg.message.guild;
@@ -88,9 +92,16 @@ export function PermissionGuard(
       return next();
     }
 
-    if (options.content instanceof MessageEmbed)
-      return post(arg, { embeds: [options.content], ephemeral: options.ephemeral ? true : false });
-    else
-      return post(arg, { content: options.content, ephemeral: options.ephemeral ? true : false });
+    if (options.content instanceof MessageEmbed) {
+      return post(arg, {
+        embeds: [options.content],
+        ephemeral: options.ephemeral ? true : false,
+      });
+    } else {
+      return post(arg, {
+        content: options.content,
+        ephemeral: options.ephemeral ? true : false,
+      });
+    }
   };
 }

--- a/packages/utilities/src/guards/PermissionGuard/types/PermissionHandlerInteraction.ts
+++ b/packages/utilities/src/guards/PermissionGuard/types/PermissionHandlerInteraction.ts
@@ -14,9 +14,3 @@ export type PermissionGuardOptions = {
   content?: string | MessageEmbed;
   ephemeral?: boolean;
 };
-
-export type PermissionReplyOptions = {
-  content?: string;
-  embeds?: MessageEmbed[];
-  ephemeral?: boolean;
-};

--- a/packages/utilities/src/guards/PermissionGuard/types/PermissionHandlerInteraction.ts
+++ b/packages/utilities/src/guards/PermissionGuard/types/PermissionHandlerInteraction.ts
@@ -1,7 +1,12 @@
-import type { CommandInteraction, ContextMenuInteraction } from "discord.js";
+import type { CommandInteraction, ContextMenuInteraction, MessageEmbed } from "discord.js";
 import type { SimpleCommandMessage } from "discordx";
 
 export type PermissionHandlerInteraction =
   | CommandInteraction
   | SimpleCommandMessage
   | ContextMenuInteraction;
+
+export type PermissionGuardOptions = {
+  content?: string | MessageEmbed;
+  ephemeral?: boolean;
+};

--- a/packages/utilities/src/guards/PermissionGuard/types/PermissionHandlerInteraction.ts
+++ b/packages/utilities/src/guards/PermissionGuard/types/PermissionHandlerInteraction.ts
@@ -1,4 +1,8 @@
-import type { CommandInteraction, ContextMenuInteraction, MessageEmbed } from "discord.js";
+import type {
+  CommandInteraction,
+  ContextMenuInteraction,
+  MessageEmbed,
+} from "discord.js";
 import type { SimpleCommandMessage } from "discordx";
 
 export type PermissionHandlerInteraction =

--- a/packages/utilities/src/guards/PermissionGuard/types/PermissionHandlerInteraction.ts
+++ b/packages/utilities/src/guards/PermissionGuard/types/PermissionHandlerInteraction.ts
@@ -14,3 +14,9 @@ export type PermissionGuardOptions = {
   content?: string | MessageEmbed;
   ephemeral?: boolean;
 };
+
+export type PermissionReplyOptions = {
+  content?: string;
+  embeds?: MessageEmbed[];
+  ephemeral?: boolean;
+};


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Simple modification who replace the content (string) option by PermissionGuardOption to control ephemeral state and choose between string or embed for reply content.

## Package
@discordx/utilities