### PR TITLE
refactor: use specific version of discord api (discord-api-types)

### DIFF
--- a/packages/discordx/src/decorators/classes/DApplicationCommand.ts
+++ b/packages/discordx/src/decorators/classes/DApplicationCommand.ts
@@ -13,7 +13,7 @@ import type {
   APIInteractionDataResolvedChannel,
   APIInteractionDataResolvedGuildMember,
   APIRole,
-} from "discord-api-types";
+} from "discord-api-types/v9";
 
 import type {
   ApplicationCommandDataX,


### PR DESCRIPTION
fix the import of the "discord-api-types" package which requires to specify the API version to use. Unable to launch with Docker if not specified.

Fixes #648

## Package

- discordx

<!--
Lines that apply to you should be moved out of the comment
- @discordx/music
- @discordx/utilities
-->
