### PR TITLE
refactor: init applications - use set operation

### DIFF
--- a/packages/discordx/src/Client.ts
+++ b/packages/discordx/src/Client.ts
@@ -921,7 +921,7 @@ export class Client extends ClientJS {
       );
     }
 
-    await this.application?.commands.set(await Promise.all(commands));
+    await this.application?.commands.set(commands);
   }
 
   /**

--- a/packages/discordx/src/Client.ts
+++ b/packages/discordx/src/Client.ts
@@ -648,17 +648,19 @@ export class Client extends ClientJS {
     }
 
     // Skipped commands should ALWAYS be added to the commands list.
-    const commands: Promise<ApplicationCommandData>[] = [
-      ...commandsToSkip.map(
-        async (cmd) => (await cmd.instance.toJSON()) as ApplicationCommandData
-      ),
+    const commands: ApplicationCommandData[] = [
+      ...(await Promise.all(
+        commandsToSkip.map((cmd) => cmd.instance.toJSON())
+      )),
     ];
 
     // If adding is ENABLED we add the new commands to the set, therefor creating the commands.
     // If adding is DISABLED we don't do anything, therefor skipping the new commands.
     if (!options?.disable?.add) {
       commands.push(
-        ...commandsToAdd.map(async (DCommand) => await DCommand.toJSON())
+        ...(await Promise.all(
+          commandsToAdd.map((DCommand) => DCommand.toJSON())
+        ))
       );
     }
 
@@ -666,12 +668,14 @@ export class Client extends ClientJS {
     // If updating is DISABLED we add the original commands back to the set, therefor skipping the commands.
     if (!options?.disable?.update) {
       commands.push(
-        ...commandsToUpdate.map(async (cmd) => await cmd.instance.toJSON())
+        ...(await Promise.all(
+          commandsToUpdate.map((cmd) => cmd.instance.toJSON())
+        ))
       );
     } else {
       commands.push(
         ...commandsWithChanges.map(
-          async (cmd) => (await cmd.toJSON()) as ApplicationCommandData
+          (cmd) => cmd.toJSON() as ApplicationCommandData
         )
       );
     }
@@ -680,13 +684,11 @@ export class Client extends ClientJS {
     // If deleting is DISABLED we DO add the commands to the set, therefor ignoring the deletion.
     if (options?.disable?.delete) {
       commands.push(
-        ...commandsToDelete.map(
-          async (cmd) => (await cmd.toJSON()) as ApplicationCommandData
-        )
+        ...commandsToDelete.map((cmd) => cmd.toJSON() as ApplicationCommandData)
       );
     }
 
-    this.application?.commands.set(await Promise.all(commands), guildId);
+    this.application?.commands.set(commands, guildId);
   }
 
   private isApplicationCommandEqual(
@@ -879,17 +881,19 @@ export class Client extends ClientJS {
     }
 
     // Skipped commands should ALWAYS be added to the commands list.
-    const commands: Promise<ApplicationCommandData>[] = [
-      ...commandsToSkip.map(
-        async (cmd) => (await cmd.instance.toJSON()) as ApplicationCommandData
-      ),
+    const commands: ApplicationCommandData[] = [
+      ...(await Promise.all(
+        commandsToSkip.map((cmd) => cmd.instance.toJSON())
+      )),
     ];
 
     // If adding is ENABLED we add the new commands to the set, therefor creating the commands.
     // If adding is DISABLED we don't do anything, therefor skipping the new commands.
     if (!options?.disable?.add) {
       commands.push(
-        ...commandsToAdd.map(async (DCommand) => await DCommand.toJSON())
+        ...(await Promise.all(
+          commandsToAdd.map((DCommand) => DCommand.toJSON())
+        ))
       );
     }
 
@@ -897,12 +901,14 @@ export class Client extends ClientJS {
     // If updating is DISABLED we add the original commands back to the set, therefor skipping the commands.
     if (!options?.disable?.update) {
       commands.push(
-        ...commandsToUpdate.map(async (cmd) => await cmd.instance.toJSON())
+        ...(await Promise.all(
+          commandsToUpdate.map((cmd) => cmd.instance.toJSON())
+        ))
       );
     } else {
       commands.push(
         ...commandsWithChanges.map(
-          async (cmd) => (await cmd.toJSON()) as ApplicationCommandData
+          (cmd) => cmd.toJSON() as ApplicationCommandData
         )
       );
     }
@@ -911,9 +917,7 @@ export class Client extends ClientJS {
     // If deleting is DISABLED we DO add the commands to the set, therefor ignoring the deletion.
     if (options?.disable?.delete) {
       commands.push(
-        ...commandsToDelete.map(
-          async (cmd) => (await cmd.toJSON()) as ApplicationCommandData
-        )
+        ...commandsToDelete.map((cmd) => cmd.toJSON() as ApplicationCommandData)
       );
     }
 

--- a/packages/discordx/src/Client.ts
+++ b/packages/discordx/src/Client.ts
@@ -778,15 +778,15 @@ export class Client extends ClientJS {
     );
 
     const commandsToAdd = DCommands.filter((DCommand) =>
-        !ApplicationCommands.find(
-            (cmd) => cmd.name === DCommand.name && cmd.type === DCommand.type
-        )
+      !ApplicationCommands.find(
+        (cmd) => cmd.name === DCommand.name && cmd.type === DCommand.type
+      )
     );
 
     const commandsToDelete = ApplicationCommands.filter((cmd) =>
-        DCommands.every(
-            (DCommand) => DCommand.name !== cmd.name || DCommand.type !== cmd.type
-        )
+      DCommands.every(
+        (DCommand) => DCommand.name !== cmd.name || DCommand.type !== cmd.type
+      )
     );
 
     const commandsWithChanges: ApplicationCommand[] = [];
@@ -794,55 +794,55 @@ export class Client extends ClientJS {
     const commandsToSkip: ApplicationCommandMixin[] = [];
 
     await Promise.all(
-    DCommands.map(async (DCommand) => {
+      DCommands.map(async (DCommand) => {
         const findCommand = ApplicationCommands.find(
-        (cmd) => cmd.name === DCommand.name && cmd.type == DCommand.type
+          (cmd) => cmd.name === DCommand.name && cmd.type == DCommand.type
         );
 
         if (!findCommand) {
-        return;
+          return;
         }
 
-        
+
         const rawData = await DCommand.toJSON();
         const commandJson = findCommand.toJSON() as ApplicationCommandData;
-        
+
         if (!this.isApplicationCommandEqual(commandJson, rawData)) {
-            commandsWithChanges.push(findCommand);
-            commandsToUpdate.push(
-                new ApplicationCommandMixin(findCommand, DCommand)
-            );
+          commandsWithChanges.push(findCommand);
+          commandsToUpdate.push(
+            new ApplicationCommandMixin(findCommand, DCommand)
+          );
         } else {
-            commandsToSkip.push(
-                new ApplicationCommandMixin(findCommand, DCommand)
-            );
+          commandsToSkip.push(
+            new ApplicationCommandMixin(findCommand, DCommand)
+          );
         }
-    })
+      })
     );
 
     // log the changes to commands if enabled by options or silent mode is turned off
     if (options?.log ?? !this.silent) {
-    let str = `${this.user?.username ?? this.botId} >> commands >> global`;
+      let str = `${this.user?.username ?? this.botId} >> commands >> global`;
 
-    str += `\n\t>> adding   ${commandsToAdd.length} [${commandsToAdd
+      str += `\n\t>> adding   ${commandsToAdd.length} [${commandsToAdd
         .map((DCommand) => DCommand.name)
         .join(", ")}]`;
 
-    str += `\n\t>> updating ${commandsToUpdate.length} [${commandsToUpdate
+      str += `\n\t>> updating ${commandsToUpdate.length} [${commandsToUpdate
         .map((cmd) => cmd.command.name)
         .join(", ")}]`;
 
-    str += `\n\t>> deleting ${commandsToDelete.size} [${commandsToDelete
+      str += `\n\t>> deleting ${commandsToDelete.size} [${commandsToDelete
         .map((cmd) => cmd.name)
         .join(", ")}]`;
 
-    str += `\n\t>> skipping ${commandsToSkip.length} [${commandsToSkip
+      str += `\n\t>> skipping ${commandsToSkip.length} [${commandsToSkip
         .map((cmd) => cmd.name)
         .join(", ")}]`;
 
-    str += "\n";
+      str += "\n";
 
-    this.logger.info(str);
+      this.logger.info(str);
     }
 
     // We don't have anything to do as everything is just skipped.
@@ -854,21 +854,21 @@ export class Client extends ClientJS {
     // If adding is ENABLED we add the new commands to the set, therefor creating the commands.
     // If adding is DISABLED we don't do anything, therefor skipping the new commands.
     if (!options?.disable?.add) {
-        commands.push(...commandsToAdd.map(async (DCommand) => await DCommand.toJSON()));
+      commands.push(...commandsToAdd.map(async (DCommand) => await DCommand.toJSON()));
     }
 
     // If updating is ENABLED we add the current commands to the set, therefor updating the commands.
     // If updating is DISABLED we add the original commands back to the set, therefor skipping the commands.
     if (!options?.disable?.update) {
-        commands.push(...commandsToUpdate.map(async (cmd) => await cmd.instance.toJSON()));
+      commands.push(...commandsToUpdate.map(async (cmd) => await cmd.instance.toJSON()));
     } else {
-        commands.push(...commandsWithChanges.map(async (cmd) => await cmd.toJSON() as ApplicationCommandData));
+      commands.push(...commandsWithChanges.map(async (cmd) => await cmd.toJSON() as ApplicationCommandData));
     }
 
     // If deleting is ENABLED we DON'T add the commands to the set, therefor deleting them from Discord.
     // If deleting is DISABLED we DO add the commands to the set, therefor ignoring the deletion.
     if (options?.disable?.delete) {
-        commands.push(...commandsToDelete.map(async (cmd) => await cmd.toJSON() as ApplicationCommandData));
+      commands.push(...commandsToDelete.map(async (cmd) => await cmd.toJSON() as ApplicationCommandData));
     }
 
     this.application?.commands.set(await Promise.all(commands));

--- a/packages/discordx/src/Client.ts
+++ b/packages/discordx/src/Client.ts
@@ -620,12 +620,12 @@ export class Client extends ClientJS {
       return;
     }
 
-    const commands = this.getApplicationCommandsUsingOptions(
+    const commands = this.getApplicationCommandsToSetUsingOptions(
       options,
       await Promise.all(commandsToSkip.map((cmd) => cmd.instance.toJSON())),
       await Promise.all(commandsToAdd.map((DCommand) => DCommand.toJSON())),
-      originalCommands.map((cmd) => cmd.toJSON() as ApplicationCommandData),
       await Promise.all(commandsToUpdate.map((cmd) => cmd.instance.toJSON())),
+      originalCommands.map((cmd) => cmd.toJSON() as ApplicationCommandData),
       commandsToDelete.map((cmd) => cmd.toJSON() as ApplicationCommandData)
     );
 
@@ -762,12 +762,12 @@ export class Client extends ClientJS {
       return;
     }
 
-    const commands = this.getApplicationCommandsUsingOptions(
+    const commands = this.getApplicationCommandsToSetUsingOptions(
       options,
       await Promise.all(commandsToSkip.map((cmd) => cmd.instance.toJSON())),
       await Promise.all(commandsToAdd.map((DCommand) => DCommand.toJSON())),
-      originalCommands.map((cmd) => cmd.toJSON() as ApplicationCommandData),
       await Promise.all(commandsToUpdate.map((cmd) => cmd.instance.toJSON())),
+      originalCommands.map((cmd) => cmd.toJSON() as ApplicationCommandData),
       commandsToDelete.map((cmd) => cmd.toJSON() as ApplicationCommandData)
     );
 
@@ -860,12 +860,12 @@ export class Client extends ClientJS {
     );
   }
 
-  private getApplicationCommandsUsingOptions(
+  private getApplicationCommandsToSetUsingOptions(
     options: InitCommandOptions | undefined,
     commandsToSkip: ApplicationCommandData[],
     commandsToAdd: ApplicationCommandData[],
-    originalCommands: ApplicationCommandData[],
     commandsToUpdate: ApplicationCommandData[],
+    originalCommands: ApplicationCommandData[],
     commandsToDelete: ApplicationCommandData[]
   ): ApplicationCommandData[] {
     const commands: ApplicationCommandData[] = commandsToSkip;

--- a/packages/discordx/src/Client.ts
+++ b/packages/discordx/src/Client.ts
@@ -666,7 +666,11 @@ export class Client extends ClientJS {
         );
 
     const operationToUpdate = options?.disable?.update
-      ? []
+      ? commandsToUpdate.map(async (cmd) =>
+          bulkUpdate.push(
+            (await cmd.command.toJSON()) as ApplicationCommandData
+          )
+        )
       : commandsToUpdate.map(async (cmd) =>
           bulkUpdate.push(
             await cmd.instance.toJSON(
@@ -900,7 +904,11 @@ export class Client extends ClientJS {
           );
 
       const operationToUpdate = options?.disable?.update
-        ? []
+        ? commandsToUpdate.map(async (cmd) =>
+            bulkUpdate.push(
+              (await cmd.command.toJSON()) as ApplicationCommandData
+            )
+          )
         : commandsToUpdate.map(async (cmd) =>
             bulkUpdate.push(await cmd.instance.toJSON())
           );

--- a/packages/discordx/src/Client.ts
+++ b/packages/discordx/src/Client.ts
@@ -639,29 +639,51 @@ export class Client extends ClientJS {
     }
 
     // We don't have anything to do as everything is just skipped.
-    if (!commandsToAdd.length && !commandsToUpdate.length && !commandsToDelete.length) return;
+    if (
+      !commandsToAdd.length &&
+      !commandsToUpdate.length &&
+      !commandsToDelete.length
+    ) {
+      return;
+    }
 
     // Skipped commands should ALWAYS be added to the commands list.
-    const commands: Promise<ApplicationCommandData>[] = [...commandsToSkip.map(async (cmd) => await cmd.instance.toJSON() as ApplicationCommandData)];
+    const commands: Promise<ApplicationCommandData>[] = [
+      ...commandsToSkip.map(
+        async (cmd) => (await cmd.instance.toJSON()) as ApplicationCommandData
+      ),
+    ];
 
     // If adding is ENABLED we add the new commands to the set, therefor creating the commands.
     // If adding is DISABLED we don't do anything, therefor skipping the new commands.
     if (!options?.disable?.add) {
-      commands.push(...commandsToAdd.map(async (DCommand) => await DCommand.toJSON()));
+      commands.push(
+        ...commandsToAdd.map(async (DCommand) => await DCommand.toJSON())
+      );
     }
 
     // If updating is ENABLED we add the current commands to the set, therefor updating the commands.
     // If updating is DISABLED we add the original commands back to the set, therefor skipping the commands.
     if (!options?.disable?.update) {
-      commands.push(...commandsToUpdate.map(async (cmd) => await cmd.instance.toJSON()));
+      commands.push(
+        ...commandsToUpdate.map(async (cmd) => await cmd.instance.toJSON())
+      );
     } else {
-      commands.push(...commandsWithChanges.map(async (cmd) => await cmd.toJSON() as ApplicationCommandData));
+      commands.push(
+        ...commandsWithChanges.map(
+          async (cmd) => (await cmd.toJSON()) as ApplicationCommandData
+        )
+      );
     }
 
     // If deleting is ENABLED we DON'T add the commands to the set, therefor deleting them from Discord.
     // If deleting is DISABLED we DO add the commands to the set, therefor ignoring the deletion.
     if (options?.disable?.delete) {
-      commands.push(...commandsToDelete.map(async (cmd) => await cmd.toJSON() as ApplicationCommandData));
+      commands.push(
+        ...commandsToDelete.map(
+          async (cmd) => (await cmd.toJSON()) as ApplicationCommandData
+        )
+      );
     }
 
     this.application?.commands.set(await Promise.all(commands), guildId);
@@ -769,7 +791,9 @@ export class Client extends ClientJS {
     );
 
     // We don't have anything to do since our app doesn't have any global commands
-    if (!ApplicationCommands?.size) return;
+    if (!ApplicationCommands?.size) {
+      return;
+    }
 
     const DCommands = this.applicationCommands.filter(
       (DCommand) =>
@@ -777,10 +801,11 @@ export class Client extends ClientJS {
         (!DCommand.botIds.length || DCommand.botIds.includes(this.botId))
     );
 
-    const commandsToAdd = DCommands.filter((DCommand) =>
-      !ApplicationCommands.find(
-        (cmd) => cmd.name === DCommand.name && cmd.type === DCommand.type
-      )
+    const commandsToAdd = DCommands.filter(
+      (DCommand) =>
+        !ApplicationCommands.find(
+          (cmd) => cmd.name === DCommand.name && cmd.type === DCommand.type
+        )
     );
 
     const commandsToDelete = ApplicationCommands.filter((cmd) =>
@@ -802,7 +827,6 @@ export class Client extends ClientJS {
         if (!findCommand) {
           return;
         }
-
 
         const rawData = await DCommand.toJSON();
         const commandJson = findCommand.toJSON() as ApplicationCommandData;
@@ -846,32 +870,54 @@ export class Client extends ClientJS {
     }
 
     // We don't have anything to do as everything is just skipped.
-    if (!commandsToAdd.length && !commandsToUpdate.length && !commandsToDelete.size) return;
+    if (
+      !commandsToAdd.length &&
+      !commandsToUpdate.length &&
+      !commandsToDelete.size
+    ) {
+      return;
+    }
 
     // Skipped commands should ALWAYS be added to the commands list.
-    const commands: Promise<ApplicationCommandData>[] = [...commandsToSkip.map(async (cmd) => await cmd.instance.toJSON() as ApplicationCommandData)];
+    const commands: Promise<ApplicationCommandData>[] = [
+      ...commandsToSkip.map(
+        async (cmd) => (await cmd.instance.toJSON()) as ApplicationCommandData
+      ),
+    ];
 
     // If adding is ENABLED we add the new commands to the set, therefor creating the commands.
     // If adding is DISABLED we don't do anything, therefor skipping the new commands.
     if (!options?.disable?.add) {
-      commands.push(...commandsToAdd.map(async (DCommand) => await DCommand.toJSON()));
+      commands.push(
+        ...commandsToAdd.map(async (DCommand) => await DCommand.toJSON())
+      );
     }
 
     // If updating is ENABLED we add the current commands to the set, therefor updating the commands.
     // If updating is DISABLED we add the original commands back to the set, therefor skipping the commands.
     if (!options?.disable?.update) {
-      commands.push(...commandsToUpdate.map(async (cmd) => await cmd.instance.toJSON()));
+      commands.push(
+        ...commandsToUpdate.map(async (cmd) => await cmd.instance.toJSON())
+      );
     } else {
-      commands.push(...commandsWithChanges.map(async (cmd) => await cmd.toJSON() as ApplicationCommandData));
+      commands.push(
+        ...commandsWithChanges.map(
+          async (cmd) => (await cmd.toJSON()) as ApplicationCommandData
+        )
+      );
     }
 
     // If deleting is ENABLED we DON'T add the commands to the set, therefor deleting them from Discord.
     // If deleting is DISABLED we DO add the commands to the set, therefor ignoring the deletion.
     if (options?.disable?.delete) {
-      commands.push(...commandsToDelete.map(async (cmd) => await cmd.toJSON() as ApplicationCommandData));
+      commands.push(
+        ...commandsToDelete.map(
+          async (cmd) => (await cmd.toJSON()) as ApplicationCommandData
+        )
+      );
     }
 
-    this.application?.commands.set(await Promise.all(commands));
+    await this.application?.commands.set(await Promise.all(commands));
   }
 
   /**

--- a/packages/discordx/src/Client.ts
+++ b/packages/discordx/src/Client.ts
@@ -642,39 +642,29 @@ export class Client extends ClientJS {
     if (!commandsToAdd.length && !commandsToUpdate.length && !commandsToDelete.length) return;
 
     // Skipped commands should ALWAYS be added to the commands list.
-    const commands: ApplicationCommandData[] = [...await Promise.all(
-        commandsToSkip.map(async (cmd) => await cmd.instance.toJSON() as ApplicationCommandData)
-    )];
+    const commands: Promise<ApplicationCommandData>[] = [...commandsToSkip.map(async (cmd) => await cmd.instance.toJSON() as ApplicationCommandData)];
 
     // If adding is ENABLED we add the new commands to the set, therefor creating the commands.
     // If adding is DISABLED we don't do anything, therefor skipping the new commands.
     if (!options?.disable?.add) {
-        commands.push(...await Promise.all(
-            commandsToAdd.map(async (DCommand) => await DCommand.toJSON())
-        ));
+      commands.push(...commandsToAdd.map(async (DCommand) => await DCommand.toJSON()));
     }
 
     // If updating is ENABLED we add the current commands to the set, therefor updating the commands.
     // If updating is DISABLED we add the original commands back to the set, therefor skipping the commands.
     if (!options?.disable?.update) {
-        commands.push(...await Promise.all(
-            commandsToUpdate.map(async (cmd) => await cmd.instance.toJSON())
-        ));
+      commands.push(...commandsToUpdate.map(async (cmd) => await cmd.instance.toJSON()));
     } else {
-        commands.push(...await Promise.all(
-            commandsWithChanges.map(async (cmd) => await cmd.toJSON() as ApplicationCommandData)
-        ));
+      commands.push(...commandsWithChanges.map(async (cmd) => await cmd.toJSON() as ApplicationCommandData));
     }
 
     // If deleting is ENABLED we DON'T add the commands to the set, therefor deleting them from Discord.
     // If deleting is DISABLED we DO add the commands to the set, therefor ignoring the deletion.
     if (options?.disable?.delete) {
-        commands.push(...await Promise.all(
-            commandsToDelete.map(async (cmd) => await cmd.toJSON() as ApplicationCommandData)
-        ));
+      commands.push(...commandsToDelete.map(async (cmd) => await cmd.toJSON() as ApplicationCommandData));
     }
 
-    this.application?.commands.set(commands, guildId);
+    this.application?.commands.set(await Promise.all(commands), guildId);
   }
 
   private isApplicationCommandEqual(
@@ -859,39 +849,29 @@ export class Client extends ClientJS {
     if (!commandsToAdd.length && !commandsToUpdate.length && !commandsToDelete.size) return;
 
     // Skipped commands should ALWAYS be added to the commands list.
-    const commands: ApplicationCommandData[] = [...await Promise.all(
-        commandsToSkip.map(async (cmd) => await cmd.instance.toJSON() as ApplicationCommandData)
-    )];
+    const commands: Promise<ApplicationCommandData>[] = [...commandsToSkip.map(async (cmd) => await cmd.instance.toJSON() as ApplicationCommandData)];
 
     // If adding is ENABLED we add the new commands to the set, therefor creating the commands.
     // If adding is DISABLED we don't do anything, therefor skipping the new commands.
     if (!options?.disable?.add) {
-        commands.push(...await Promise.all(
-            commandsToAdd.map(async (DCommand) => await DCommand.toJSON())
-        ));
+        commands.push(...commandsToAdd.map(async (DCommand) => await DCommand.toJSON()));
     }
 
     // If updating is ENABLED we add the current commands to the set, therefor updating the commands.
     // If updating is DISABLED we add the original commands back to the set, therefor skipping the commands.
     if (!options?.disable?.update) {
-        commands.push(...await Promise.all(
-            commandsToUpdate.map(async (cmd) => await cmd.instance.toJSON())
-        ));
+        commands.push(...commandsToUpdate.map(async (cmd) => await cmd.instance.toJSON()));
     } else {
-        commands.push(...await Promise.all(
-            commandsWithChanges.map(async (cmd) => await cmd.toJSON() as ApplicationCommandData)
-        ));
+        commands.push(...commandsWithChanges.map(async (cmd) => await cmd.toJSON() as ApplicationCommandData));
     }
 
     // If deleting is ENABLED we DON'T add the commands to the set, therefor deleting them from Discord.
     // If deleting is DISABLED we DO add the commands to the set, therefor ignoring the deletion.
     if (options?.disable?.delete) {
-        commands.push(...await Promise.all(
-            commandsToDelete.map(async (cmd) => await cmd.toJSON() as ApplicationCommandData)
-        ));
+        commands.push(...commandsToDelete.map(async (cmd) => await cmd.toJSON() as ApplicationCommandData));
     }
 
-    this.application?.commands.set(commands);
+    this.application?.commands.set(await Promise.all(commands));
   }
 
   /**

--- a/packages/discordx/src/Client.ts
+++ b/packages/discordx/src/Client.ts
@@ -674,9 +674,7 @@ export class Client extends ClientJS {
       );
     } else {
       commands.push(
-        ...originalCommands.map(
-          (cmd) => cmd.toJSON() as ApplicationCommandData
-        )
+        ...originalCommands.map((cmd) => cmd.toJSON() as ApplicationCommandData)
       );
     }
 
@@ -907,9 +905,7 @@ export class Client extends ClientJS {
       );
     } else {
       commands.push(
-        ...originalCommands.map(
-          (cmd) => cmd.toJSON() as ApplicationCommandData
-        )
+        ...originalCommands.map((cmd) => cmd.toJSON() as ApplicationCommandData)
       );
     }
 

--- a/packages/discordx/src/Client.ts
+++ b/packages/discordx/src/Client.ts
@@ -543,9 +543,6 @@ export class Client extends ClientJS {
     // fetch already registered guild commands
     const ApplicationCommands = await guild.commands.fetch();
 
-    // We don't have anything to do since this guild doesn't have any commands
-    if (!ApplicationCommands?.size) return;
-
     // filter only unregistered application command
     const commandsToAdd = DCommands.filter(
       (DCommand) =>

--- a/packages/discordx/src/Client.ts
+++ b/packages/discordx/src/Client.ts
@@ -553,7 +553,7 @@ export class Client extends ClientJS {
 
     // filter application command to update
 
-    const commandsWithChanges: ApplicationCommand[] = [];
+    const originalCommands: ApplicationCommand[] = [];
     const commandsToUpdate: ApplicationCommandMixin[] = [];
     const commandsToSkip: ApplicationCommandMixin[] = [];
 
@@ -574,7 +574,7 @@ export class Client extends ClientJS {
         const commandJson = findCommand.toJSON() as ApplicationCommandData;
 
         if (!this.isApplicationCommandEqual(commandJson, rawData)) {
-          commandsWithChanges.push(findCommand);
+          originalCommands.push(findCommand);
           commandsToUpdate.push(
             new ApplicationCommandMixin(findCommand, DCommand)
           );
@@ -674,7 +674,7 @@ export class Client extends ClientJS {
       );
     } else {
       commands.push(
-        ...commandsWithChanges.map(
+        ...originalCommands.map(
           (cmd) => cmd.toJSON() as ApplicationCommandData
         )
       );
@@ -688,7 +688,7 @@ export class Client extends ClientJS {
       );
     }
 
-    this.application?.commands.set(commands, guildId);
+    await this.application?.commands.set(commands, guildId);
   }
 
   private isApplicationCommandEqual(
@@ -816,7 +816,7 @@ export class Client extends ClientJS {
       )
     );
 
-    const commandsWithChanges: ApplicationCommand[] = [];
+    const originalCommands: ApplicationCommand[] = [];
     const commandsToUpdate: ApplicationCommandMixin[] = [];
     const commandsToSkip: ApplicationCommandMixin[] = [];
 
@@ -834,7 +834,7 @@ export class Client extends ClientJS {
         const commandJson = findCommand.toJSON() as ApplicationCommandData;
 
         if (!this.isApplicationCommandEqual(commandJson, rawData)) {
-          commandsWithChanges.push(findCommand);
+          originalCommands.push(findCommand);
           commandsToUpdate.push(
             new ApplicationCommandMixin(findCommand, DCommand)
           );
@@ -907,7 +907,7 @@ export class Client extends ClientJS {
       );
     } else {
       commands.push(
-        ...commandsWithChanges.map(
+        ...originalCommands.map(
           (cmd) => cmd.toJSON() as ApplicationCommandData
         )
       );


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
As discussed in issue #697, this changes application command updates from using `n` requests to `1` request*. This will fix rate limits simply by not making nearly as many requests.

Note: 1 request per guild and 1 request for global commands, there seems to be no way around having to do a request per guild.

## Package
- discordx