### PR TITLE
feat: include a custom message placeholder for time remaining

### DIFF
--- a/packages/utilities/examples/guards/commands/RateLimit.ts
+++ b/packages/utilities/examples/guards/commands/RateLimit.ts
@@ -40,6 +40,23 @@ export class RateLimitExample {
   }
 
   /**
+   * only one command every 30 seconds with custom message including time
+   *
+   * @param interaction
+   */
+  @Slash("rate_limit_4")
+  @Guard(
+    RateLimit(
+      TIME_UNIT.seconds,
+      30,
+      "Slow Down, please try at {until}, if you do not try at {until} then this command will not work"
+    )
+  )
+  rateLimit4(interaction: CommandInteraction): void {
+    interaction.reply("It worked!");
+  }
+
+  /**
    * Rate limit simple command
    *
    * @param message

--- a/packages/utilities/src/guards/Rate Limiter/RateLimit.ts
+++ b/packages/utilities/src/guards/Rate Limiter/RateLimit.ts
@@ -15,7 +15,8 @@ import { TimeOutEntry } from "./logic/index.js";
  * @param timeout - the time unit to use
  * @param value - the value for the time unit
  * @param message - the message to post when a command is called when the
- * user is in rate limit, defaults = "message being rate limited!, please try again at {until}". use the placeholder {until} in your string to get time you can next call it `<t:epoch:T>`
+ * user is in rate limit, defaults = "message being rate limited!, please try again at {until}".
+ * use the placeholder {until} in your string to get the time you can next call it `<t:epoch:T>`
  * @param rateValue - the value to specify how many messages can be called before it is rate limited, defaults to 1
  *
  * @constructor

--- a/packages/utilities/src/guards/Rate Limiter/RateLimit.ts
+++ b/packages/utilities/src/guards/Rate Limiter/RateLimit.ts
@@ -15,7 +15,7 @@ import { TimeOutEntry } from "./logic/index.js";
  * @param timeout - the time unit to use
  * @param value - the value for the time unit
  * @param message - the message to post when a command is called when the
- * user is in rate limit, defaults = "message being rate limited!"
+ * user is in rate limit, defaults = "message being rate limited!, please try again at {until}". use the placeholder {until} in your string to get time you can next call it `<t:epoch:T>`
  * @param rateValue - the value to specify how many messages can be called before it is rate limited, defaults to 1
  *
  * @constructor
@@ -23,7 +23,7 @@ import { TimeOutEntry } from "./logic/index.js";
 export function RateLimit(
   timeout: TIME_UNIT,
   value: number,
-  message = "message being rate limited!",
+  message = "message being rate limited!, please try again at {until}",
   rateValue = 1
 ): GuardFunction<BaseCommandInteraction | SimpleCommandMessage> {
   function convertToMillisecond(timeValue: number, unit: TIME_UNIT): number {
@@ -41,8 +41,8 @@ export function RateLimit(
     }
   }
 
-  const millisecond = convertToMillisecond(value, timeout);
-  const _timer = new TimedSet<TimeOutEntry>(millisecond);
+  const _millisecond = convertToMillisecond(value, timeout);
+  const _timer = new TimedSet<TimeOutEntry>(_millisecond);
 
   async function replyOrFollowUp(
     interaction: BaseCommandInteraction | MessageComponentInteraction,
@@ -78,6 +78,10 @@ export function RateLimit(
     );
   }
 
+  function getTimeLeft(item: TimeOutEntry): number {
+    return _timer.getTimeRemaining(item);
+  }
+
   async function post(
     arg: BaseCommandInteraction | SimpleCommandMessage,
     msg: string
@@ -109,6 +113,16 @@ export function RateLimit(
     if (fromArray) {
       fromArray.incrementCallCount();
       if (fromArray.hasLimitReached()) {
+        if (message.includes("{until}")) {
+          const whenWillExecute = Date.now() + getTimeLeft(fromArray);
+          return post(
+            arg,
+            message.replaceAll(
+              "{until}",
+              `<t:${Math.round(whenWillExecute / 1000)}:T>`
+            )
+          );
+        }
         return post(arg, message);
       }
 

--- a/packages/utilities/src/guards/Rate Limiter/logic/TimedSet.ts
+++ b/packages/utilities/src/guards/Rate Limiter/logic/TimedSet.ts
@@ -1,4 +1,4 @@
-import type { ITimedSet } from "../types";
+import type { ITimedSet } from "../types/index.js";
 import { Timer } from "./index.js";
 
 /**

--- a/packages/utilities/src/guards/Rate Limiter/logic/Timer.ts
+++ b/packages/utilities/src/guards/Rate Limiter/logic/Timer.ts
@@ -1,0 +1,20 @@
+import Timeout = NodeJS.Timeout;
+
+export class Timer {
+  public id: Timeout;
+  private _whenWillExecute: number;
+
+  public constructor(callback: (...args: unknown[]) => void, delay: number) {
+    this._whenWillExecute = Date.now() + delay;
+    this.id = setTimeout(callback, delay);
+  }
+
+  public get timeLeft(): number {
+    return this._whenWillExecute - Date.now();
+  }
+
+  public clearTimer(): void {
+    clearTimeout(this.id);
+    this._whenWillExecute = -1;
+  }
+}

--- a/packages/utilities/src/guards/Rate Limiter/logic/index.ts
+++ b/packages/utilities/src/guards/Rate Limiter/logic/index.ts
@@ -1,2 +1,3 @@
 export * from "./TimedSet.js";
 export * from "./TimeOutEntry.js";
+export * from "./Timer.js";

--- a/packages/utilities/src/guards/Rate Limiter/types/ITimedSet.ts
+++ b/packages/utilities/src/guards/Rate Limiter/types/ITimedSet.ts
@@ -13,7 +13,7 @@ export interface ITimedSet<T> extends Set<T> {
   isEmpty(): boolean;
 
   /**
-   * Refresh the timeout fot this element (resets the timer for the items' eviction)
+   * Refresh the timeout for this element (resets the timer for the items eviction)
    *
    * @param key - Key
    */

--- a/packages/utilities/src/guards/Rate Limiter/types/ITimedSet.ts
+++ b/packages/utilities/src/guards/Rate Limiter/types/ITimedSet.ts
@@ -3,12 +3,17 @@
  */
 export interface ITimedSet<T> extends Set<T> {
   /**
+   * Get the time left until this item is removed from the set
+   */
+  getTimeRemaining(key: T): number;
+
+  /**
    * checks if this set is empty
    */
   isEmpty(): boolean;
 
   /**
-   * Refresh the timeout fot this element (resets the timer for this items eviction
+   * Refresh the timeout fot this element (resets the timer for the items' eviction)
    *
    * @param key - Key
    */


### PR DESCRIPTION
Added the ability to be able to inject the time in which the next execution is in the custom message via {until} in the format `<t:epoch:T>`
While i could have made callback to "format" the message. it's not worth it, i think `<t:T>` is fine for this use case

## Package

@discordx/utilities
