### PR TITLE
fix: solve rate limits in clear commands

### DIFF
--- a/packages/discordx/src/Client.ts
+++ b/packages/discordx/src/Client.ts
@@ -1110,28 +1110,13 @@ export class Client extends ClientJS {
   async clearApplicationCommands(...guilds: Snowflake[]): Promise<void> {
     if (guilds.length) {
       await Promise.all(
-        guilds.map(async (guild) => {
-          // Select and delete the commands of each guild
-          const commands = await this.fetchApplicationCommands(guild);
-          if (commands) {
-            await Promise.all(
-              commands.map((value) => {
-                this.guilds.cache.get(guild)?.commands.delete(value);
-              })
-            );
-          }
+        // Select and delete the commands of each guild
+        guilds.map((guild) => {
+          this.guilds.cache.get(guild)?.commands.set([]);
         })
       );
     } else {
-      // Select and delete the commands of each guild
-      const commands = await this.fetchApplicationCommands();
-      if (commands) {
-        await Promise.all(
-          commands.map(async (command) => {
-            await this.application?.commands.delete(command);
-          })
-        );
-      }
+      await this.application?.commands.set([]);
     }
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Using `set` with an empty array can be used to clear commands in one command, vastly speeding up `clearApplicationCommands` and solving the 5 per 20 seconds rate limit. As a bonus, can also get rid of the `fetchApplicationCommands` now.

I personally plan to use this to get around the `nameLocalizations` issue, but the current method is just way too slow to be feasible. This turns it from a multi-minute process to a quick clean way to clear commands.

Tested. Works fine with both global commands and snowflakes.

## Package

- discordx
