### PR TITLE
fix: @discordx/importer ESM exports

### DIFF
--- a/packages/importer/package.json
+++ b/packages/importer/package.json
@@ -26,7 +26,8 @@
   "exports": {
     ".": {
       "import": "./build/esm/index.mjs",
-      "require": "./build/cjs/index.cjs"
+      "require": "./build/cjs/index.cjs",
+      "types": "./index.d.ts"
     }
   },
   "main": "./build/cjs/index.cjs",


### PR DESCRIPTION
This PR fixes an issue in `@discordx/importer` where, if you configured your `tsconfig.json` to use `NodeNext` module resolution, the types will not be located by tsc. This is because upon enabling `NodeNext`, tsc no longer falls back to the root `types` declaration. Both declarations are required for full ESM compatibility.
## Package

- @discordx/importer
