### PR TITLE
feat: declarative reaction handlers

### DIFF
--- a/docs/docs/decorators/general/reaction.md
+++ b/docs/docs/decorators/general/reaction.md
@@ -1,0 +1,141 @@
+# @Reaction
+
+Create a reaction handler for messages using `@Reaction`.
+
+:::warning
+Reaction handlers do not currently support permissions. Guards may be used instead.
+:::
+
+## Example
+
+```ts
+@Discord()
+class Example {
+  @Reaction("📌")
+  async pin(reaction: MessageReaction): Promise<void> {
+    await reaction.message.pin();
+  }
+}
+```
+
+### Execute Reactions
+
+You have to manually execute your reactions by using `client.executeReaction(reaction, user)`
+
+```ts
+import { Client } from "discordx";
+
+async function start() {
+  const client = new Client({
+    botId: "test",
+    intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES],
+    partials: ["MESSAGE", "CHANNEL", "REACTION"], // Necessary to receive reactions for uncached messages
+  });
+
+  client.on("messageReactionAdd", (reaction, user) => {
+    this.Client.executeReaction(reaction, user);
+  });
+  await client.login("YOUR_TOKEN");
+}
+
+start();
+```
+
+### Aliasing Reactions
+```ts
+@Reaction("📌", { aliases: ["📍", "custom_emoji"] })
+async pin(reaction: MessageReaction): Promise<void> {
+  await reaction.message.pin();
+}
+```
+
+### Retain Reactions
+
+By default, reactions will be removed when being executed. To prevent this, set the `delete` option to `false`.
+
+```ts
+@Reaction("⭐", { remove: false })
+async starReaction(reaction: MessageReaction, user: User): Promise<void> {
+  await reaction.message.reply(`Received a ${reaction.emoji} from ${user}`);
+}
+```
+
+## Signature
+
+```ts
+Reaction(name: string, options: ReactionOptions)
+```
+
+## Parameters
+
+### name
+
+The reaction emoji, either unicode, custom emoji name, or custom emoji snowflake.
+
+| type   | default | required |
+| ------ | ------- | -------- |
+| string |         | Yes      |
+
+### options
+
+Multiple options, check below.
+
+| type   | default   | required |
+| ------ | --------- | -------- |
+| object | undefined | No       |
+
+#### `remove`
+
+Whether or not to remove the reaction upon execution.
+
+| type      | default |
+| --------- | ------- |
+| boolean   | true    |
+
+#### `aliases`
+
+Alternative emojis for this reaction handler.
+
+| type      | default |
+| --------- | ------- |
+| string[ ] | [ ]     |
+
+#### `partial`
+
+If enabled, discord.ts will not fetch the reaction or user when they are partial.
+
+| type      | default |
+| --------- | ------- |
+| boolean   | false   |
+
+#### `Description`
+
+A description of what the reaction does.
+
+| type   | default      |
+| ------ | ------------ |
+| string |              |
+
+#### `botIds`
+
+Array of bot ids which the reaction will be executed on.
+
+| type      | default |
+| --------- | ------- |
+| string[ ] | [ ]     |
+
+#### `directMessage`
+
+Allow reaction execution from direct messages.
+
+| type    | default |
+| ------- | ------- |
+| boolean | true    |
+
+#### `guilds`
+
+Array of guild ids which the reaction will be executed in.
+
+| type         | default |
+| ------------ | ------- |
+| Snowflake[ ] | [ ]     |

--- a/packages/discordx/examples/reaction/commands/common.ts
+++ b/packages/discordx/examples/reaction/commands/common.ts
@@ -1,0 +1,16 @@
+import type { MessageReaction, User } from "discord.js";
+
+import { Discord, Reaction } from "../../../src/index.js";
+
+@Discord()
+export class Example {
+  @Reaction("⭐", { remove: false })
+  async starReaction(reaction: MessageReaction, user: User): Promise<void> {
+    await reaction.message.reply(`Received a ${reaction.emoji} from ${user}`);
+  }
+
+  @Reaction("📌", { aliases: ["📍", "custom_emoji"] })
+  async pin(reaction: MessageReaction): Promise<void> {
+    await reaction.message.pin();
+  }
+}

--- a/packages/discordx/examples/reaction/main.ts
+++ b/packages/discordx/examples/reaction/main.ts
@@ -1,0 +1,46 @@
+import "reflect-metadata";
+
+import { Intents } from "discord.js";
+
+import { dirname, importx } from "../../../importer/build/esm/index.mjs";
+import { Client } from "../../src/index.js";
+
+export class Main {
+  private static _client: Client;
+
+  static get Client(): Client {
+    return this._client;
+  }
+
+  static async start(): Promise<void> {
+    this._client = new Client({
+      botGuilds: [(client) => client.guilds.cache.map((guild) => guild.id)],
+      intents: [
+        Intents.FLAGS.GUILDS,
+        Intents.FLAGS.GUILD_MESSAGES,
+        Intents.FLAGS.GUILD_MEMBERS,
+        Intents.FLAGS.GUILD_MESSAGE_REACTIONS,
+      ],
+      partials: ["MESSAGE", "CHANNEL", "REACTION"],
+      silent: false,
+    });
+
+    this.Client.on("ready", () => {
+      console.log("Bot started...");
+    });
+
+    this.Client.on("messageReactionAdd", (reaction, user) => {
+      this.Client.executeReaction(reaction, user);
+    });
+
+    await importx(dirname(import.meta.url) + "/commands/**/*.{js,ts}");
+
+    // let's start the bot
+    if (!process.env.BOT_TOKEN) {
+      throw Error("Could not find BOT_TOKEN in your environment");
+    }
+    await this._client.login(process.env.BOT_TOKEN);
+  }
+}
+
+Main.start();

--- a/packages/discordx/examples/reaction/tsconfig.json
+++ b/packages/discordx/examples/reaction/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "target": "ESNext",
+    "strict": true,
+    "noImplicitAny": true,
+    "outDir": "build",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "importHelpers": true,
+    "strictNullChecks": true,
+    "noUncheckedIndexedAccess": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "Node",
+    "esModuleInterop": true
+  },
+  "exclude": ["node_modules", "tests", "examples"]
+}

--- a/packages/discordx/src/Client.ts
+++ b/packages/discordx/src/Client.ts
@@ -1603,7 +1603,7 @@ export class Client extends ClientJS {
     message: MessageReaction | PartialMessageReaction
   ): DReaction | undefined {
     const reaction = this.reactions.find((react) => {
-      const validNames = [react.name, ...react.aliases];
+      const validNames = [react.emoji, ...react.aliases];
       const { emoji } = message;
 
       return (

--- a/packages/discordx/src/decorators/classes/DDiscord.ts
+++ b/packages/discordx/src/decorators/classes/DDiscord.ts
@@ -6,6 +6,7 @@ import type {
   DComponent,
   DGuard,
   DOn,
+  DReaction,
   DSimpleCommand,
   IGuild,
   IPermissions,
@@ -28,6 +29,7 @@ export class DDiscord extends Decorator {
   private _permissions: IPermissions[] = [];
   private _selectMenuComponents: DComponent[] = [];
   private _simpleCommands: DSimpleCommand[] = [];
+  private _reactions: DReaction[] = [];
 
   get applicationCommands(): DApplicationCommand[] {
     return this._applicationCommands;
@@ -122,6 +124,13 @@ export class DDiscord extends Decorator {
   }
   set simpleCommands(value: DSimpleCommand[]) {
     this._simpleCommands = value;
+  }
+
+  get reactions(): DReaction[] {
+    return this._reactions;
+  }
+  set reactions(value: DReaction[]) {
+    this._reactions = value;
   }
 
   protected constructor(name: string, description?: string) {

--- a/packages/discordx/src/decorators/classes/DReaction.ts
+++ b/packages/discordx/src/decorators/classes/DReaction.ts
@@ -6,7 +6,7 @@ import { Method } from "./Method.js";
  * @category Decorator
  */
 export class DReaction extends Method {
-  private _name: string;
+  private _emoji: string;
   private _description: string;
   private _directMessage: boolean;
   private _guilds: IGuild[];
@@ -43,11 +43,11 @@ export class DReaction extends Method {
     this._directMessage = value;
   }
 
-  get name(): string {
-    return this._name;
+  get emoji(): string {
+    return this._emoji;
   }
-  set name(value: string) {
-    this._name = value;
+  set emoji(value: string) {
+    this._emoji = value;
   }
 
   get description(): string {
@@ -72,7 +72,7 @@ export class DReaction extends Method {
   }
 
   protected constructor(
-    name: string,
+    emoji: string,
     aliases?: string[],
     botIds?: string[],
     description?: string,
@@ -82,8 +82,8 @@ export class DReaction extends Method {
     partial?: boolean
   ) {
     super();
-    this._name = name;
-    this._description = description ?? this.name;
+    this._emoji = emoji;
+    this._description = description ?? this.emoji;
     this._directMessage = directMessage ?? true;
     this._guilds = guilds ?? [];
     this._botIds = botIds ?? [];
@@ -93,7 +93,7 @@ export class DReaction extends Method {
   }
 
   static create(
-    name: string,
+    emoji: string,
     aliases?: string[],
     botIds?: string[],
     description?: string,
@@ -103,7 +103,7 @@ export class DReaction extends Method {
     partial?: boolean
   ): DReaction {
     return new DReaction(
-      name,
+      emoji,
       aliases,
       botIds,
       description,

--- a/packages/discordx/src/decorators/classes/DReaction.ts
+++ b/packages/discordx/src/decorators/classes/DReaction.ts
@@ -1,0 +1,154 @@
+import type { Client, IGuild } from "../../index.js";
+import { resolveIGuilds } from "../../index.js";
+import { Method } from "./Method.js";
+
+/**
+ * @category Decorator
+ */
+export class DReaction extends Method {
+  private _name: string;
+  private _description: string;
+  private _directMessage: boolean;
+  private _guilds: IGuild[];
+  private _botIds: string[];
+  private _aliases: string[];
+  private _remove: boolean;
+  private _partial: boolean;
+
+  get aliases(): string[] {
+    return this._aliases;
+  }
+  set aliases(value: string[]) {
+    this._aliases = value;
+  }
+
+  get botIds(): string[] {
+    return this._botIds;
+  }
+  set botIds(value: string[]) {
+    this._botIds = value;
+  }
+
+  get guilds(): IGuild[] {
+    return this._guilds;
+  }
+  set guilds(value: IGuild[]) {
+    this._guilds = value;
+  }
+
+  get directMessage(): boolean {
+    return this._directMessage;
+  }
+  set directMessage(value: boolean) {
+    this._directMessage = value;
+  }
+
+  get name(): string {
+    return this._name;
+  }
+  set name(value: string) {
+    this._name = value;
+  }
+
+  get description(): string {
+    return this._description;
+  }
+  set description(value: string) {
+    this._description = value;
+  }
+
+  get remove(): boolean {
+    return this._remove;
+  }
+  set remove(value: boolean) {
+    this._remove = value;
+  }
+
+  get partial(): boolean {
+    return this._partial;
+  }
+  set partial(value: boolean) {
+    this._partial = value;
+  }
+
+  protected constructor(
+    name: string,
+    aliases?: string[],
+    botIds?: string[],
+    description?: string,
+    directMessage?: boolean,
+    guilds?: IGuild[],
+    remove?: boolean,
+    partial?: boolean
+  ) {
+    super();
+    this._name = name;
+    this._description = description ?? this.name;
+    this._directMessage = directMessage ?? true;
+    this._guilds = guilds ?? [];
+    this._botIds = botIds ?? [];
+    this._aliases = aliases ?? [];
+    this._remove = remove ?? true;
+    this._partial = partial ?? false;
+  }
+
+  static create(
+    name: string,
+    aliases?: string[],
+    botIds?: string[],
+    description?: string,
+    directMessage?: boolean,
+    guilds?: IGuild[],
+    remove?: boolean,
+    partial?: boolean
+  ): DReaction {
+    return new DReaction(
+      name,
+      aliases,
+      botIds,
+      description,
+      directMessage,
+      guilds,
+      remove,
+      partial
+    );
+  }
+
+  isBotAllowed(botId: string): boolean {
+    if (!this.botIds.length) {
+      return true;
+    }
+
+    return this.botIds.includes(botId);
+  }
+
+  async getGuilds(client: Client): Promise<string[]> {
+    const guilds = await resolveIGuilds(client, this, [
+      ...client.botGuilds,
+      ...this.guilds,
+    ]);
+
+    return guilds;
+  }
+
+  async isGuildAllowed(
+    client: Client,
+    guildId: string | null
+  ): Promise<boolean> {
+    if (!guildId) {
+      return true;
+    }
+
+    const guilds = await this.getGuilds(client);
+
+    if (!guilds.length) {
+      return true;
+    }
+
+    return guilds.includes(guildId);
+  }
+
+  parseParams(): never[] {
+    return [];
+  }
+}

--- a/packages/discordx/src/decorators/classes/index.ts
+++ b/packages/discordx/src/decorators/classes/index.ts
@@ -6,5 +6,6 @@ export * from "./DComponent.js";
 export * from "./DDiscord.js";
 export * from "./DGuard.js";
 export * from "./DOn.js";
+export * from "./DReaction.js";
 export * from "./DSimpleCommand.js";
 export * from "./DSimpleCommandOption.js";

--- a/packages/discordx/src/decorators/decorators/Bot.ts
+++ b/packages/discordx/src/decorators/decorators/Bot.ts
@@ -7,6 +7,7 @@ import {
   DComponent,
   DDiscord,
   DOn,
+  DReaction,
   DSimpleCommand,
   MetadataStorage,
 } from "../../index.js";
@@ -45,7 +46,12 @@ export function Bot(...botIds: string[]): ClassMethodDecorator {
   ) {
     MetadataStorage.instance.addModifier(
       Modifier.create<
-        DApplicationCommand | DSimpleCommand | DDiscord | DComponent | DOn
+        | DApplicationCommand
+        | DSimpleCommand
+        | DReaction
+        | DDiscord
+        | DComponent
+        | DOn
       >(
         (original) => {
           original.botIds = [
@@ -57,6 +63,7 @@ export function Bot(...botIds: string[]): ClassMethodDecorator {
             [
               ...original.applicationCommands,
               ...original.simpleCommands,
+              ...original.reactions,
               ...original.buttons,
               ...original.selectMenus,
               ...original.events,
@@ -70,6 +77,7 @@ export function Bot(...botIds: string[]): ClassMethodDecorator {
         },
         DApplicationCommand,
         DSimpleCommand,
+        DReaction,
         DDiscord,
         DComponent,
         DOn

--- a/packages/discordx/src/decorators/decorators/Guard.ts
+++ b/packages/discordx/src/decorators/decorators/Guard.ts
@@ -8,6 +8,7 @@ import {
   DDiscord,
   DGuard,
   DOn,
+  DReaction,
   DSimpleCommand,
   MetadataStorage,
 } from "../../index.js";
@@ -46,6 +47,7 @@ export function Guard<Type = any, DataType = any>(
         DComponent,
         DApplicationCommand,
         DSimpleCommand,
+        DReaction,
         DOn,
         DDiscord
       ).decorateUnknown(target, key, descriptor)

--- a/packages/discordx/src/decorators/decorators/Guild.ts
+++ b/packages/discordx/src/decorators/decorators/Guild.ts
@@ -6,6 +6,7 @@ import {
   DApplicationCommand,
   DComponent,
   DDiscord,
+  DReaction,
   DSimpleCommand,
   MetadataStorage,
 } from "../../index.js";
@@ -42,7 +43,7 @@ export function Guild(...guildIds: IGuild[]): ClassMethodDecorator {
   ) {
     MetadataStorage.instance.addModifier(
       Modifier.create<
-        DApplicationCommand | DSimpleCommand | DDiscord | DComponent
+        DApplicationCommand | DSimpleCommand | DReaction | DDiscord | DComponent
       >(
         (original) => {
           original.guilds = [...original.guilds, ...guildIds];
@@ -60,6 +61,7 @@ export function Guild(...guildIds: IGuild[]): ClassMethodDecorator {
         },
         DApplicationCommand,
         DSimpleCommand,
+        DReaction,
         DDiscord,
         DComponent
       ).decorateUnknown(target, key, descriptor)

--- a/packages/discordx/src/decorators/decorators/Reaction.ts
+++ b/packages/discordx/src/decorators/decorators/Reaction.ts
@@ -1,0 +1,34 @@
+import type { MethodDecoratorEx } from "@discordx/internal";
+
+import type { NotEmpty, ReactionOptions } from "../../index.js";
+import { MetadataStorage } from "../../index.js";
+import { DReaction } from "../classes/DReaction.js";
+
+export function Reaction<T extends string>(
+  name: NotEmpty<T>
+): MethodDecoratorEx;
+
+export function Reaction<T extends string>(
+  name: NotEmpty<T>,
+  options: ReactionOptions
+): MethodDecoratorEx;
+
+export function Reaction(
+  name: string,
+  options?: ReactionOptions
+): MethodDecoratorEx {
+  return function <T>(target: Record<string, T>, key: string) {
+    const react = DReaction.create(
+      name,
+      options?.aliases,
+      options?.botIds,
+      options?.description,
+      options?.directMessage,
+      options?.guilds,
+      options?.remove,
+      options?.partial
+    ).decorate(target.constructor, key, target[key]);
+
+    MetadataStorage.instance.addReaction(react);
+  };
+}

--- a/packages/discordx/src/decorators/decorators/Reaction.ts
+++ b/packages/discordx/src/decorators/decorators/Reaction.ts
@@ -4,22 +4,52 @@ import type { NotEmpty, ReactionOptions } from "../../index.js";
 import { MetadataStorage } from "../../index.js";
 import { DReaction } from "../classes/DReaction.js";
 
+/**
+ * Handle a reaction with a specified emoji
+ *
+ * @param emoji - Emoji, in the form of a Unicode string, custom name, or Snowflake.
+ * ___
+ *
+ * [View Documentation](https://discord-ts.js.org/docs/decorators/general/reaction)
+ *
+ * @category Decorator
+ */
 export function Reaction<T extends string>(
-  name: NotEmpty<T>
+  emoji: NotEmpty<T>
 ): MethodDecoratorEx;
 
+/**
+ * Handle a reaction with a specified emoji
+ *
+ * @param emoji - Emoji, in the form of a Unicode string, custom name, or Snowflake.
+ * ___
+ *
+ * [View Documentation](https://discord-ts.js.org/docs/decorators/general/reaction)
+ *
+ * @category Decorator
+ */
 export function Reaction<T extends string>(
-  name: NotEmpty<T>,
+  emoji: NotEmpty<T>,
   options: ReactionOptions
 ): MethodDecoratorEx;
 
+/**
+ * Handle a reaction with a specified emoji
+ *
+ * @param emoji - Emoji, in the form of a Unicode string, custom name, or Snowflake.
+ * ___
+ *
+ * [View Documentation](https://discord-ts.js.org/docs/decorators/general/reaction)
+ *
+ * @category Decorator
+ */
 export function Reaction(
-  name: string,
+  emoji: string,
   options?: ReactionOptions
 ): MethodDecoratorEx {
   return function <T>(target: Record<string, T>, key: string) {
     const react = DReaction.create(
-      name,
+      emoji,
       options?.aliases,
       options?.botIds,
       options?.description,

--- a/packages/discordx/src/decorators/decorators/index.ts
+++ b/packages/discordx/src/decorators/decorators/index.ts
@@ -8,6 +8,7 @@ export * from "./ModalComponent.js";
 export * from "./On.js";
 export * from "./Once.js";
 export * from "./Permission.js";
+export * from "./Reaction.js";
 export * from "./SelectMenuComponent.js";
 export * from "./SimpleCommand.js";
 export * from "./SimpleCommandOption.js";

--- a/packages/discordx/src/logic/metadata/MetadataStorage.ts
+++ b/packages/discordx/src/logic/metadata/MetadataStorage.ts
@@ -21,6 +21,7 @@ import {
   DApplicationCommandOption,
   DComponent,
   DOn,
+  DReaction,
   DSimpleCommand,
 } from "../../index.js";
 
@@ -49,6 +50,9 @@ export class MetadataStorage {
   private _simpleCommands: Array<DSimpleCommand> = [];
   private _simpleCommandsByName: Array<ISimpleCommandByName> = [];
   private _simpleCommandsByPrefix = new Map<string, ISimpleCommandByName[]>();
+
+  // reactions
+  private _reactions: Array<DReaction> = [];
 
   // discord commands
   private _applicationCommandMessages: Array<DApplicationCommand> = [];
@@ -137,6 +141,7 @@ export class MetadataStorage {
       ...this._applicationCommandUsers,
       ...this._applicationCommandMessages,
       ...this._simpleCommands,
+      ...this.reactions,
       ...this._events,
       ...this._buttonComponents,
       ...this._modalComponents,
@@ -170,6 +175,10 @@ export class MetadataStorage {
 
   get simpleCommands(): readonly DSimpleCommand[] {
     return this._simpleCommands;
+  }
+
+  get reactions(): readonly DReaction[] {
+    return this._reactions;
   }
 
   /**
@@ -254,6 +263,10 @@ export class MetadataStorage {
     this._simpleCommandOptions.push(cmdOption);
   }
 
+  addReaction(reaction: DReaction): void {
+    this._reactions.push(reaction);
+  }
+
   async build(): Promise<void> {
     // build the instance if not already built
     if (MetadataStorage.isBuilt) {
@@ -285,6 +298,10 @@ export class MetadataStorage {
 
       if (member instanceof DSimpleCommand) {
         discord.simpleCommands.push(member);
+      }
+
+      if (member instanceof DReaction) {
+        discord.reactions.push(member);
       }
 
       if (member instanceof DOn) {
@@ -331,6 +348,11 @@ export class MetadataStorage {
     await Modifier.applyFromModifierListToList(
       this._modifiers,
       this._simpleCommandOptions
+    );
+
+    await Modifier.applyFromModifierListToList(
+      this._modifiers,
+      this._reactions
     );
 
     await Modifier.applyFromModifierListToList(

--- a/packages/discordx/src/types/core/common.ts
+++ b/packages/discordx/src/types/core/common.ts
@@ -11,6 +11,7 @@ import type {
   DApplicationCommand,
   DComponent,
   DefaultPermissionResolver,
+  DReaction,
   DSimpleCommand,
   SimpleCommandMessage,
 } from "../../index.js";
@@ -47,6 +48,7 @@ export type IGuild =
       command:
         | DApplicationCommand
         | DComponent
+        | DReaction
         | SimpleCommandMessage
         | undefined
     ) => Snowflake | Snowflake[] | Promise<Snowflake> | Promise<Snowflake[]>);

--- a/packages/discordx/src/types/public/index.ts
+++ b/packages/discordx/src/types/public/index.ts
@@ -1,4 +1,5 @@
 export * from "./common.js";
 export * from "./enum.js";
+export * from "./reaction.js";
 export * from "./simple command.js";
 export * from "./slash.js";

--- a/packages/discordx/src/types/public/reaction.ts
+++ b/packages/discordx/src/types/public/reaction.ts
@@ -1,0 +1,11 @@
+import type { IGuild } from "../index.js";
+
+export type ReactionOptions = {
+  aliases?: string[];
+  botIds?: string[];
+  description?: string;
+  directMessage?: boolean;
+  guilds?: IGuild[];
+  partial?: boolean;
+  remove?: boolean;
+};

--- a/packages/discordx/src/util/common.ts
+++ b/packages/discordx/src/util/common.ts
@@ -6,6 +6,7 @@ import type {
   Client,
   DApplicationCommand,
   DComponent,
+  DReaction,
   IGuild,
   IPermissions,
   SimpleCommandMessage,
@@ -13,7 +14,12 @@ import type {
 
 export const resolveIGuilds = async (
   client: Client,
-  command: DApplicationCommand | DComponent | SimpleCommandMessage | undefined,
+  command:
+    | DApplicationCommand
+    | DComponent
+    | SimpleCommandMessage
+    | DReaction
+    | undefined,
   guilds: IGuild[]
 ): Promise<string[]> => {
   const guildX = await Promise.all(


### PR DESCRIPTION
##  Description
This PR adds a new decorator, `@Reaction`, which supports declaring a handler for reactions with the specified emoji.

## Why
This significantly simplifies listening to (and optionally removing) reactions, and avoids the creation of repetitive event handlers.

## Concerns
There still exist a few concerns for this implementation, namely:
 - Lack of support for permissions.
 - No deferred emoji resolution, so custom emojis must be matched by name or snowflake directly.

## Package

- discordx

