### PR TITLE
fix(lava-player): cannot get node for players

### DIFF
--- a/packages/lava-player/src/base/Cluster.ts
+++ b/packages/lava-player/src/base/Cluster.ts
@@ -57,8 +57,13 @@ export abstract class BaseCluster extends EventEmitter {
   public getNode(guildId: string): ClusterNode {
     let node = this.nodes.find((nodeX) => nodeX.players.has(guildId));
 
-    if (!node) node = this.sort().find((nodeX) => this.filter(nodeX, guildId));
-    if (node) return node;
+    if (!node) {
+      node = this.sort().find((nodeX) => this.filter(nodeX, guildId));
+    }
+
+    if (node) {
+      return node;
+    }
 
     throw new Error(
       "unable to find appropriate node; please check your filter"

--- a/packages/lava-player/src/base/Cluster.ts
+++ b/packages/lava-player/src/base/Cluster.ts
@@ -57,11 +57,8 @@ export abstract class BaseCluster extends EventEmitter {
   public getNode(guildId: string): ClusterNode {
     let node = this.nodes.find((nodeX) => nodeX.players.has(guildId));
 
-    if (!node) {
-      node = this.sort().find((nodeX) => this.filter(nodeX, guildId));
-    } else {
-      return node;
-    }
+    if (!node) node = this.sort().find((nodeX) => this.filter(nodeX, guildId));
+    if (node) return node;
 
     throw new Error(
       "unable to find appropriate node; please check your filter"


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This solves the problem that searching for a node for the player searches for a new node in the if condition and never satisfies the logic of the else condition, which returns the node.

## Package
`@discordx/lavaplayer`

<!--
Lines that apply to you should be moved out of the comment
- discordx
- @discordx/music
- @discordx/utilities
-->
