### PR TITLE
docs: syntax SlashChoicesType to SlashChoiceType

### DIFF
--- a/docs/docs/decorators/commands/slash-choice.md
+++ b/docs/docs/decorators/commands/slash-choice.md
@@ -72,7 +72,7 @@ class Example {
 ```ts
 SlashChoice(...choices: string[]);
 SlashChoice(...choices: number[]);
-SlashChoice(...choices: SlashChoicesType[]);
+SlashChoice(...choices: SlashChoiceType[]);
 ```
 
 ## Parameters


### PR DESCRIPTION
Fixing a little mistake in the documentation of SlashChoiceType

## Package
`docs`
