### PR TITLE
fix(lava-player): the VoiceStateUpdate event payload was not completely saved

### DIFF
--- a/packages/lava-player/src/base/Node.ts
+++ b/packages/lava-player/src/base/Node.ts
@@ -25,7 +25,7 @@ export abstract class BaseNode extends EventEmitter {
   public players: PlayerStore<this> = new PlayerStore(this);
   public http: Http;
 
-  public voiceStates: Map<string, string> = new Map();
+  public voiceStates: Map<string, VoiceStateUpdate> = new Map();
   public voiceServers: Map<string, VoiceServerUpdate> = new Map();
 
   private _expectingConnection: Set<string> = new Set();
@@ -83,7 +83,7 @@ export abstract class BaseNode extends EventEmitter {
     }
 
     if (packet.channel_id) {
-      this.voiceStates.set(packet.guild_id, packet.session_id);
+      this.voiceStates.set(packet.guild_id, packet);
       return this._tryConnection(packet.guild_id);
     } else {
       this.voiceServers.delete(packet.guild_id);
@@ -124,7 +124,7 @@ export abstract class BaseNode extends EventEmitter {
       return false;
     }
 
-    await this.players.get(guildId).voiceUpdate(state, server);
+    await this.players.get(guildId).voiceUpdate(state.session_id, server);
     this._expectingConnection.delete(guildId);
     return true;
   }

--- a/packages/lava-player/src/core/Player.ts
+++ b/packages/lava-player/src/core/Player.ts
@@ -64,16 +64,12 @@ export class Player<T extends BaseNode = BaseNode> extends EventEmitter {
   }
 
   public get voiceState(): VoiceStateUpdate | undefined {
-    const session = this.node.voiceStates.get(this.guildId);
-    if (!session) {
+    const state = this.node.voiceStates.get(this.guildId);
+    if (!state) {
       return;
     }
 
-    return {
-      guild_id: this.guildId,
-      session_id: session,
-      user_id: this.node.userId,
-    };
+    return state;
   }
 
   public get voiceServer(): VoiceServerUpdate | undefined {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Previously lava-player only stored the session id of the VoiceStateUpdate event, it is useful for internal stuff but when you want to know more about the current player's voice state it is not so useful. What this does is to save the complete payload of the VoiceStateUpdate event and be able to get it in the player.

Note: It was supposed to be this way because of the types that the Player class has.

## Package
@discordx/lava-player

<!--
Lines that apply to you should be moved out of the comment
- discordx
- @discordx/music
- @discordx/utilities
-->
