### PR TITLE
refactor: use object instead plain arguments

### DIFF
--- a/packages/discordx/examples/attachment/commands/common.ts
+++ b/packages/discordx/examples/attachment/commands/common.ts
@@ -5,9 +5,12 @@ import { Discord, Slash, SlashOption } from "../../../src/index.js";
 
 @Discord()
 export class Example {
-  @Slash("attachment")
+  @Slash()
   attachment(
-    @SlashOption("image", { type: ApplicationCommandOptionType.Attachment })
+    @SlashOption({
+      name: "image",
+      type: ApplicationCommandOptionType.Attachment,
+    })
     attachment: Attachment,
     interaction: CommandInteraction
   ): void {

--- a/packages/discordx/examples/button/commands/common.ts
+++ b/packages/discordx/examples/button/commands/common.ts
@@ -9,12 +9,12 @@ import { ButtonComponent, Discord, Slash } from "../../../src/index.js";
 
 @Discord()
 export class Example {
-  @ButtonComponent("hello")
+  @ButtonComponent({ id: "hello" })
   handler(interaction: ButtonInteraction): void {
     interaction.reply(":wave:");
   }
 
-  @ButtonComponent("hello")
+  @ButtonComponent({ id: "hello" })
   handler2(interaction: ButtonInteraction): void {
     console.log(`${interaction.user} says hello`);
   }

--- a/packages/discordx/examples/button/commands/game.ts
+++ b/packages/discordx/examples/button/commands/game.ts
@@ -76,9 +76,10 @@ const defaultChoice = new RPSProposition(
 
 @Discord()
 export class RockPaperScissors {
-  @Slash("rock-paper-scissors", {
+  @Slash({
     description:
       "What could be more fun than play Rock Paper Scissors with a bot?",
+    name: "rock-paper-scissors",
   })
   private async RPS(
     @SlashChoice(
@@ -95,9 +96,10 @@ export class RockPaperScissors {
         value: RPSChoice.Scissors,
       }
     )
-    @SlashOption("choice", {
+    @SlashOption({
       description:
         "Your choose. If empty, it will send a message with buttons to choose and play instead.",
+      name: "choice",
       required: false,
       type: ApplicationCommandOptionType.Number,
     })
@@ -156,9 +158,9 @@ export class RockPaperScissors {
     }
   }
 
-  @ButtonComponent(`RPS-${RPSChoice.Rock}`)
-  @ButtonComponent(`RPS-${RPSChoice.Paper}`)
-  @ButtonComponent(`RPS-${RPSChoice.Scissors}`)
+  @ButtonComponent({ id: `RPS-${RPSChoice.Rock}` })
+  @ButtonComponent({ id: `RPS-${RPSChoice.Paper}` })
+  @ButtonComponent({ id: `RPS-${RPSChoice.Scissors}` })
   private async RPSButton(interaction: ButtonInteraction) {
     await interaction.deferReply();
 

--- a/packages/discordx/examples/command/commands/common.ts
+++ b/packages/discordx/examples/command/commands/common.ts
@@ -10,28 +10,34 @@ import {
 
 @Discord()
 export class Example {
-  @SimpleCommand("bool")
+  @SimpleCommand()
   bool(
-    @SimpleCommandOption("state") bool: boolean,
+    @SimpleCommandOption({
+      name: "state",
+      type: SimpleCommandOptionType.Boolean,
+    })
+    state: boolean | undefined,
     command: SimpleCommandMessage
   ): void {
-    command.message.reply(String(bool));
+    command.message.reply(state ? String(state) : "state is required");
   }
 
-  @SimpleCommand("race", { prefix: ["&", ">"] })
+  @SimpleCommand({ prefix: ["&", ">"] })
   race(command: SimpleCommandMessage): void {
     command.sendUsageSyntax();
   }
 
-  @SimpleCommand("race car", {
+  @SimpleCommand({
     description: "simple command example",
+    name: "race car",
     prefix: ["&", ">"],
   })
   car(
-    @SimpleCommandOption("user", { type: SimpleCommandOptionType.User })
+    @SimpleCommandOption({ name: "user", type: SimpleCommandOptionType.User })
     user: GuildMember | User | Error | undefined,
-    @SimpleCommandOption("role", {
+    @SimpleCommandOption({
       description: "mention the role you wish to grant",
+      name: "role",
       type: SimpleCommandOptionType.Role,
     })
     role: Role | Error | undefined,
@@ -46,7 +52,7 @@ export class Example {
         );
   }
 
-  @SimpleCommand("race bike", { prefix: ["&", ">"] })
+  @SimpleCommand({ name: "race bike", prefix: ["&", ">"] })
   bike(command: SimpleCommandMessage): void {
     command.message.reply(
       `command prefix: \`\`${command.prefix.toString()}\`\`\ncommand name: \`\`${
@@ -55,9 +61,9 @@ export class Example {
     );
   }
 
-  @SimpleCommand("test-x", { prefix: ["&", ">"] })
+  @SimpleCommand({ name: "test-x", prefix: ["&", ">"] })
   testX(
-    @SimpleCommandOption("user", { type: SimpleCommandOptionType.User })
+    @SimpleCommandOption({ name: "user", type: SimpleCommandOptionType.User })
     user: GuildMember | User | Error | undefined,
     command: SimpleCommandMessage
   ): void {

--- a/packages/discordx/examples/command/commands/math.ts
+++ b/packages/discordx/examples/command/commands/math.ts
@@ -13,16 +13,31 @@ export class Example {
   // single whitespace will be used to split options
   // command aliases: !m, !solve
   // string or regex supported for argSplitter
-  @SimpleCommand("calc math add", {
+  @SimpleCommand({
     aliases: ["m", "solve"],
     argSplitter: /s/,
     directMessage: true,
+    name: "calc math add",
   })
   cmd(
-    @SimpleCommandOption("num1", { description: "first value" }) num1: number,
-    @SimpleCommandOption("operation", { description: "Operation (+, -, *, /)" })
-    operation: string,
-    @SimpleCommandOption("num2", { description: "second value" }) num2: number,
+    @SimpleCommandOption({
+      description: "first value",
+      name: "num1",
+      type: SimpleCommandOptionType.Number,
+    })
+    num1: number | undefined,
+    @SimpleCommandOption({
+      description: "Operation (+, -, *, /)",
+      name: "operation",
+      type: SimpleCommandOptionType.String,
+    })
+    operation: string | undefined,
+    @SimpleCommandOption({
+      description: "second value",
+      name: "num2",
+      type: SimpleCommandOptionType.Number,
+    })
+    num2: number | undefined,
     command: SimpleCommandMessage
   ): unknown {
     if (
@@ -52,14 +67,14 @@ export class Example {
     command.message.reply(`${num1} ${operation} ${num2} = ${out}`);
   }
 
-  @SimpleCommand("perm-check", { aliases: ["p-check"] })
+  @SimpleCommand({ aliases: ["p-check"], name: "perm-check" })
   permFunc(command: SimpleCommandMessage): void {
     command.message.reply("access granted");
   }
 
-  @SimpleCommand("hello", { aliases: ["p-test mark"] })
+  @SimpleCommand({ aliases: ["p-test mark"], name: "hello" })
   testCommand(
-    @SimpleCommandOption("name") name: string,
+    @SimpleCommandOption({ name: "name" }) name: string | undefined,
 
     command: SimpleCommandMessage
   ): unknown {
@@ -70,10 +85,10 @@ export class Example {
 
   // mention test
 
-  @SimpleCommand("mention-test-user")
+  @SimpleCommand({ name: "mention-test-user" })
   handler(
-    @SimpleCommandOption("user", { type: SimpleCommandOptionType.User })
-    user: User, //
+    @SimpleCommandOption({ name: "user", type: SimpleCommandOptionType.User })
+    user: User | undefined, //
     command: SimpleCommandMessage
   ): void {
     !user
@@ -81,10 +96,10 @@ export class Example {
       : command.message.reply(`${user}`);
   }
 
-  @SimpleCommand("mention-test-role")
+  @SimpleCommand({ name: "mention-test-role" })
   handlerRole(
-    @SimpleCommandOption("role", { type: SimpleCommandOptionType.Role })
-    role: Role, //
+    @SimpleCommandOption({ name: "role", type: SimpleCommandOptionType.Role })
+    role: Role | undefined, //
     command: SimpleCommandMessage
   ): void {
     !role
@@ -92,10 +107,13 @@ export class Example {
       : command.message.reply(`${role}`);
   }
 
-  @SimpleCommand("mention-test-channel")
+  @SimpleCommand({ name: "mention-test-channel" })
   handlerChannel(
-    @SimpleCommandOption("channel", { type: SimpleCommandOptionType.Channel })
-    channel: Channel, //
+    @SimpleCommandOption({
+      name: "channel",
+      type: SimpleCommandOptionType.Channel,
+    })
+    channel: Channel | undefined, //
     command: SimpleCommandMessage
   ): void {
     !channel
@@ -103,50 +121,60 @@ export class Example {
       : command.message.reply(`${channel}`);
   }
 
-  @SimpleCommand("add", { argSplitter: "+" })
+  @SimpleCommand({ argSplitter: "+", name: "add" })
   add(
-    @SimpleCommandOption("x") x: number,
-    @SimpleCommandOption("y") y: number,
+    @SimpleCommandOption({ name: "x" }) x: number,
+    @SimpleCommandOption({ name: "y" }) y: number,
     command: SimpleCommandMessage
   ): void {
-    !command.isValid()
-      ? command.sendUsageSyntax()
-      : command.message.reply(`${x + y}`);
+    if (!command.isValid()) {
+      command.sendUsageSyntax();
+      return;
+    }
+
+    command.message.reply(`${x + y}`);
   }
 
-  @SimpleCommand("ban", {
+  @SimpleCommand({
     argSplitter:
       /\s\"|\s'|"|'|\s(?=(?:"[^"]*"|[^"])*$)(?=(?:'[^']*'|[^'])*$)/gm,
   })
   ban(
-    @SimpleCommandOption("id") id: number,
-    @SimpleCommandOption("time") time: number,
-    @SimpleCommandOption("reason") reason: string,
-    @SimpleCommandOption("type") type: string,
+    @SimpleCommandOption({ name: "id" }) id: number,
+    @SimpleCommandOption({ name: "time" }) time: number,
+    @SimpleCommandOption({ name: "reason" }) reason: string,
+    @SimpleCommandOption({ name: "type" }) type: string,
     command: SimpleCommandMessage
   ): void {
-    !command.isValid()
-      ? command.sendUsageSyntax()
-      : command.message.reply(
-          `id: ${id}\n` +
-            `time: ${time} seconds\n` +
-            `reason: ${reason}\n` +
-            `Type: ${type}`
-        );
+    if (!command.isValid()) {
+      command.sendUsageSyntax();
+      return;
+    }
+
+    command.message.reply(
+      `id: ${id}\n` +
+        `time: ${time} seconds\n` +
+        `reason: ${reason}\n` +
+        `Type: ${type}`
+    );
   }
 
-  @SimpleCommand("split-me", {
+  @SimpleCommand({
     argSplitter: (command) => {
       return command.argString.split("|");
     },
+    name: "split-me",
   })
   splitMe(
-    @SimpleCommandOption("arg1") arg1: string,
-    @SimpleCommandOption("arg2") arg2: string,
+    @SimpleCommandOption({ name: "arg1" }) arg1: string,
+    @SimpleCommandOption({ name: "arg2" }) arg2: string,
     command: SimpleCommandMessage
   ): void {
-    !command.isValid()
-      ? command.sendUsageSyntax()
-      : command.message.reply(`arg1: ${arg1}\n` + `arg2: ${arg2}\n`);
+    if (!command.isValid()) {
+      command.sendUsageSyntax();
+      return;
+    }
+
+    command.message.reply(`arg1: ${arg1}\n` + `arg2: ${arg2}\n`);
   }
 }

--- a/packages/discordx/examples/contextmenu/commands/common.ts
+++ b/packages/discordx/examples/contextmenu/commands/common.ts
@@ -8,13 +8,19 @@ import { ContextMenu, Discord } from "../../../src/index.js";
 
 @Discord()
 export class Example {
-  @ContextMenu(ApplicationCommandType.Message, "Hello from discord.ts")
+  @ContextMenu({
+    name: "Hello from discord.ts",
+    type: ApplicationCommandType.Message,
+  })
   messageHandler(interaction: MessageContextMenuCommandInteraction): void {
     console.log("I am message");
     interaction.reply("message interaction works");
   }
 
-  @ContextMenu(ApplicationCommandType.User, "Hello from discord.ts")
+  @ContextMenu({
+    name: "Hello from discord.ts",
+    type: ApplicationCommandType.User,
+  })
   userHandler(interaction: UserContextMenuCommandInteraction): void {
     console.log(`Selected user: ${interaction.targetId}`);
     interaction.reply("user interaction works");

--- a/packages/discordx/examples/di/tsyringe/commands/common.ts
+++ b/packages/discordx/examples/di/tsyringe/commands/common.ts
@@ -25,7 +25,7 @@ export class Example {
     // I am just a empty constructor :(
   }
 
-  @Slash("tsyringe")
+  @Slash()
   tsyringe(interaction: CommandInteraction): void {
     if (DIService.engine === tsyringeDependencyRegistryEngine) {
       const clazz = container.resolve(Example);
@@ -37,7 +37,7 @@ export class Example {
     }
   }
 
-  @Slash("tsyringe2")
+  @Slash()
   tsyringe2(interaction: CommandInteraction): void {
     if (DIService.engine === tsyringeDependencyRegistryEngine) {
       interaction.reply(this.database.query());

--- a/packages/discordx/examples/di/typedi/commands/common.ts
+++ b/packages/discordx/examples/di/typedi/commands/common.ts
@@ -45,7 +45,7 @@ export class ConstructorInjection {
     console.log(namedDatabase);
   }
 
-  @Slash("typedi")
+  @Slash()
   typedi(interaction: CommandInteraction): void {
     if (DIService.engine === typeDiDependencyRegistryEngine) {
       const clazz = Container.get(ConstructorInjection);
@@ -59,7 +59,7 @@ export class ConstructorInjection {
     }
   }
 
-  @Slash("typedi2")
+  @Slash()
   typedi2(interaction: CommandInteraction): void {
     if (DIService.engine === typeDiDependencyRegistryEngine) {
       interaction.reply(this.database.query());
@@ -77,7 +77,7 @@ export class PropertyInjectionExample {
   @Inject("myDb")
   private namedDatabase!: NamedDatabase;
 
-  @Slash("typedi_prop_injection")
+  @Slash({ name: "typedi_prop_injection" })
   typedi(interaction: CommandInteraction): void {
     if (
       DIService.engine === typeDiDependencyRegistryEngine &&
@@ -95,7 +95,7 @@ export class PropertyInjectionExample {
     }
   }
 
-  @Slash("typedi_prop_injection2")
+  @Slash({ name: "typedi_prop_injection2" })
   typedi2(interaction: CommandInteraction): void {
     if (DIService.engine === typeDiDependencyRegistryEngine) {
       if (this.database) {

--- a/packages/discordx/examples/event/commands/common.ts
+++ b/packages/discordx/examples/event/commands/common.ts
@@ -3,13 +3,13 @@ import { Discord, On } from "../../../src/index.js";
 
 @Discord()
 export class Example {
-  @On("messageCreate")
-  onMessage([message]: ArgsOf<"messageCreate">): void {
+  @On()
+  messageCreate([message]: ArgsOf<"messageCreate">): void {
     console.log(message.content);
   }
 
-  @On("messageReactionAdd")
-  emoji([reaction, user]: ArgsOf<"messageReactionAdd">): void {
+  @On()
+  messageReactionAdd([reaction, user]: ArgsOf<"messageReactionAdd">): void {
     const member = reaction.message.guild?.members.resolve(user.id);
     if (member) {
       console.log(member.roles.cache.map((r) => r.name));

--- a/packages/discordx/examples/guards/commands/common.ts
+++ b/packages/discordx/examples/guards/commands/common.ts
@@ -7,19 +7,19 @@ import { NotBot } from "../guards/NotBot.js";
 
 @Discord()
 export class Example {
-  @On("messageCreate")
+  @On()
   @Guard(NotBot)
-  onMessage([message]: ArgsOf<"messageCreate">): void {
+  messageCreate([message]: ArgsOf<"messageCreate">): void {
     console.log(message.content);
   }
 
-  @Slash("hello")
+  @Slash()
   @Guard(NotBot)
   hello(interaction: CommandInteraction): void {
     console.log(interaction);
   }
 
-  @Slash("error-guard")
+  @Slash({ name: "error-guard" })
   @Guard(ErrorHandler, NotBot)
   errorGuard(): void {
     throw Error("My custom error");

--- a/packages/discordx/examples/guards/commands/interaction guard.ts
+++ b/packages/discordx/examples/guards/commands/interaction guard.ts
@@ -12,7 +12,7 @@ export const InteractionGuard: GuardFunction<
 
 @Discord()
 export class Example {
-  @ContextMenu(ApplicationCommandType.User, "Check details")
+  @ContextMenu({ name: "Check details", type: ApplicationCommandType.User })
   @Guard(InteractionGuard)
   userHandler(interaction: ContextMenuCommandInteraction): void {
     console.log(`Selected user: ${interaction.targetId}`);

--- a/packages/discordx/examples/localization/commands/common.ts
+++ b/packages/discordx/examples/localization/commands/common.ts
@@ -5,14 +5,15 @@ import { Discord, Slash, SlashOption } from "../../../src/index.js";
 
 @Discord()
 export class Example {
-  @Slash("hello", {
+  @Slash({
     description: "say hello",
     nameLocalizations: {
       "en-GB": "hello-x",
     },
   })
-  voiceChannel(
-    @SlashOption("message", {
+  hello(
+    @SlashOption({
+      name: "message",
       type: ApplicationCommandOptionType.String,
     })
     message: string,

--- a/packages/discordx/examples/localization/commands/group.ts
+++ b/packages/discordx/examples/localization/commands/group.ts
@@ -8,15 +8,16 @@ import { Discord, Slash, SlashGroup, SlashOption } from "../../../src/index.js";
 @SlashGroup({ name: "maths", root: "testing" })
 @SlashGroup({ name: "text", root: "testing" })
 export class Example {
-  @Slash("voice-channel")
+  @Slash({ name: "voice-channel" })
   @SlashGroup("maths", "testing")
   voiceChannel(
-    @SlashOption("channel", {
+    @SlashOption({
       channelTypes: [
         ChannelType.GuildCategory,
         ChannelType.GuildVoice,
         ChannelType.GuildText,
       ],
+      name: "channel",
       type: ApplicationCommandOptionType.Channel,
     })
     roleOrUser: GuildMember | User | Role,
@@ -25,14 +26,15 @@ export class Example {
     interaction.reply(`${roleOrUser}`);
   }
 
-  @Slash("voice-channel-x")
+  @Slash({ name: "voice-channel-x" })
   voiceChannelX(
-    @SlashOption("channel", {
+    @SlashOption({
       channelTypes: [
         ChannelType.GuildCategory,
         ChannelType.GuildVoice,
         ChannelType.GuildText,
       ],
+      name: "channel",
       type: ApplicationCommandOptionType.Channel,
     })
     roleOrUser: GuildMember | User | Role,
@@ -41,21 +43,21 @@ export class Example {
     interaction.reply(`${roleOrUser}`);
   }
 
-  @Slash("add")
+  @Slash()
   @SlashGroup("maths", "testing")
   add(
-    @SlashOption("x", { description: "x value" }) x: number,
-    @SlashOption("y", { description: "y value" }) y: number,
+    @SlashOption({ description: "x value", name: "x" }) x: number,
+    @SlashOption({ description: "y value", name: "y" }) y: number,
     interaction: CommandInteraction
   ): void {
     interaction.reply(String(x + y));
   }
 
-  @Slash("multiply")
+  @Slash()
   @SlashGroup("maths", "testing")
   multiply(
-    @SlashOption("x", { description: "x value" }) x: number,
-    @SlashOption("y", { description: "y value" }) y: number,
+    @SlashOption({ description: "x value", name: "x" }) x: number,
+    @SlashOption({ description: "y value", name: "y" }) y: number,
     interaction: CommandInteraction
   ): void {
     interaction.reply(String(x * y));

--- a/packages/discordx/examples/localization/commands/permission.ts
+++ b/packages/discordx/examples/localization/commands/permission.ts
@@ -5,26 +5,26 @@ import { Discord, Slash } from "../../../src/index.js";
 
 @Discord()
 export class Example {
-  @Slash("perm1", { defaultMemberPermissions: BigInt(0) })
+  @Slash({ defaultMemberPermissions: BigInt(0) })
   perm1(interaction: ChatInputCommandInteraction): void {
     interaction.reply(":wave:");
   }
 
-  @Slash("perm2", {
+  @Slash({
     defaultMemberPermissions: PermissionFlagsBits.Administrator,
   })
   perm2(interaction: ChatInputCommandInteraction): void {
     interaction.reply(":wave:");
   }
 
-  @Slash("perm3", {
+  @Slash({
     dmPermission: true,
   })
   perm3(interaction: ChatInputCommandInteraction): void {
     interaction.reply(":wave:");
   }
 
-  @Slash("perm4", {
+  @Slash({
     dmPermission: true,
     guilds: ["874802018361950248"],
   })
@@ -32,7 +32,7 @@ export class Example {
     interaction.reply(":wave:");
   }
 
-  @Slash("perm5", {
+  @Slash({
     defaultMemberPermissions: undefined,
     guilds: ["874802018361950248"],
   })
@@ -40,7 +40,7 @@ export class Example {
     interaction.reply(":wave:");
   }
 
-  @Slash("perm6", {
+  @Slash({
     defaultMemberPermissions: PermissionFlagsBits.Administrator,
     guilds: ["874802018361950248"],
   })

--- a/packages/discordx/examples/menu/commands/common.ts
+++ b/packages/discordx/examples/menu/commands/common.ts
@@ -15,7 +15,7 @@ const roles = [
 
 @Discord()
 export class Example {
-  @SelectMenuComponent("role-menu")
+  @SelectMenuComponent({ id: "role-menu" })
   async handle(interaction: SelectMenuInteraction): Promise<unknown> {
     await interaction.deferReply();
 
@@ -35,7 +35,7 @@ export class Example {
     return;
   }
 
-  @Slash("my-roles", { description: "roles menu" })
+  @Slash({ description: "roles menu", name: "my-roles" })
   async myRoles(interaction: CommandInteraction): Promise<unknown> {
     await interaction.deferReply();
 

--- a/packages/discordx/examples/modal/commands/common.ts
+++ b/packages/discordx/examples/modal/commands/common.ts
@@ -10,8 +10,8 @@ import { Discord, ModalComponent, Slash } from "../../../src/index.js";
 
 @Discord()
 export class Example {
-  @Slash("modal")
-  attachment(interaction: CommandInteraction): void {
+  @Slash()
+  modal(interaction: CommandInteraction): void {
     // Create the modal
     const modal = new ModalBuilder()
       .setTitle("My Awesome Form")
@@ -45,8 +45,8 @@ export class Example {
     interaction.showModal(modal);
   }
 
-  @ModalComponent("AwesomeForm")
-  async handle(interaction: ModalSubmitInteraction): Promise<void> {
+  @ModalComponent()
+  async AwesomeForm(interaction: ModalSubmitInteraction): Promise<void> {
     const [favTVShow, favHaiku] = ["tvField", "haikuField"].map((id) =>
       interaction.fields.getTextInputValue(id)
     );

--- a/packages/discordx/examples/multiple bots/commands/botA.ts
+++ b/packages/discordx/examples/multiple bots/commands/botA.ts
@@ -5,8 +5,8 @@ import { Bot, Discord, Slash } from "../../../src/index.js";
 @Discord()
 @Bot("botA") // A bot id is crucial
 export class Example {
-  @Slash("hello")
-  root(interaction: CommandInteraction): void {
+  @Slash()
+  hello(interaction: CommandInteraction): void {
     interaction.reply("I am bot A.");
   }
 }

--- a/packages/discordx/examples/multiple bots/commands/botB.ts
+++ b/packages/discordx/examples/multiple bots/commands/botB.ts
@@ -5,8 +5,8 @@ import { Bot, Discord, Slash } from "../../../src/index.js";
 @Discord()
 @Bot("botB") // A bot id is crucial
 export class Example {
-  @Slash("hello")
-  root(interaction: CommandInteraction): void {
+  @Slash()
+  hello(interaction: CommandInteraction): void {
     interaction.reply("I am bot B.");
   }
 }

--- a/packages/discordx/examples/multiple bots/commands/common.ts
+++ b/packages/discordx/examples/multiple bots/commands/common.ts
@@ -5,8 +5,8 @@ import { Bot, Discord, Slash } from "../../../src/index.js";
 @Discord()
 @Bot("botA", "botB") // A bot id is crucial
 export class Example {
-  @Slash("shared")
-  root(interaction: CommandInteraction): void {
+  @Slash()
+  shared(interaction: CommandInteraction): void {
     interaction.reply("This is a shared command and can be used by both bots");
   }
 }

--- a/packages/discordx/examples/multiple-discord-instances/commands/commandA.ts
+++ b/packages/discordx/examples/multiple-discord-instances/commands/commandA.ts
@@ -4,8 +4,8 @@ import { Discord, Slash } from "../../../src/index.js";
 
 @Discord()
 export class CommandA {
-  @Slash("hello")
-  hello1(interaction: CommandInteraction): void {
+  @Slash()
+  hello(interaction: CommandInteraction): void {
     interaction.reply(":wave:");
   }
 }

--- a/packages/discordx/examples/multiple-discord-instances/commands/commandB.ts
+++ b/packages/discordx/examples/multiple-discord-instances/commands/commandB.ts
@@ -4,8 +4,8 @@ import { Discord, Slash } from "../../../src/index.js";
 
 @Discord()
 export class CommandB {
-  @Slash("hi")
-  hello1(interaction: CommandInteraction): void {
+  @Slash()
+  hi(interaction: CommandInteraction): void {
     interaction.reply(":wave:");
   }
 }

--- a/packages/discordx/examples/permission/commands/common.ts
+++ b/packages/discordx/examples/permission/commands/common.ts
@@ -5,26 +5,26 @@ import { Discord, Slash } from "../../../src/index.js";
 
 @Discord()
 export class Example {
-  @Slash("perm1", { defaultMemberPermissions: BigInt(0) })
+  @Slash({ defaultMemberPermissions: BigInt(0) })
   perm1(interaction: ChatInputCommandInteraction): void {
     interaction.reply(":wave:");
   }
 
-  @Slash("perm2", {
+  @Slash({
     defaultMemberPermissions: PermissionFlagsBits.Administrator,
   })
   perm2(interaction: ChatInputCommandInteraction): void {
     interaction.reply(":wave:");
   }
 
-  @Slash("perm3", {
+  @Slash({
     dmPermission: true,
   })
   perm3(interaction: ChatInputCommandInteraction): void {
     interaction.reply(":wave:");
   }
 
-  @Slash("perm4", {
+  @Slash({
     dmPermission: true,
     guilds: ["874802018361950248"],
   })
@@ -32,7 +32,7 @@ export class Example {
     interaction.reply(":wave:");
   }
 
-  @Slash("perm5", {
+  @Slash({
     defaultMemberPermissions: undefined,
     guilds: ["874802018361950248"],
   })
@@ -40,7 +40,7 @@ export class Example {
     interaction.reply(":wave:");
   }
 
-  @Slash("perm6", {
+  @Slash({
     defaultMemberPermissions: PermissionFlagsBits.Administrator,
     guilds: ["874802018361950248"],
   })

--- a/packages/discordx/examples/permission/commands/group.ts
+++ b/packages/discordx/examples/permission/commands/group.ts
@@ -10,12 +10,12 @@ import { Discord, Slash, SlashGroup } from "../../../src/index.js";
 })
 @SlashGroup("vital")
 export class Example {
-  @Slash("perm1")
+  @Slash()
   perm1(interaction: ChatInputCommandInteraction): void {
     interaction.reply(":wave:");
   }
 
-  @Slash("perm2")
+  @Slash()
   perm2(interaction: ChatInputCommandInteraction): void {
     interaction.reply(":wave:");
   }

--- a/packages/discordx/examples/reaction/commands/common.ts
+++ b/packages/discordx/examples/reaction/commands/common.ts
@@ -4,12 +4,12 @@ import { Discord, Reaction } from "../../../src/index.js";
 
 @Discord()
 export class Example {
-  @Reaction("⭐", { remove: false })
+  @Reaction({ emoji: "⭐", remove: true })
   async starReaction(reaction: MessageReaction, user: User): Promise<void> {
     await reaction.message.reply(`Received a ${reaction.emoji} from ${user}`);
   }
 
-  @Reaction("📌", { aliases: ["📍", "custom_emoji"] })
+  @Reaction({ aliases: ["📍", "custom_emoji"], emoji: "📌" })
   async pin(reaction: MessageReaction): Promise<void> {
     await reaction.message.pin();
   }

--- a/packages/discordx/examples/slash/commands/common.ts
+++ b/packages/discordx/examples/slash/commands/common.ts
@@ -27,50 +27,57 @@ import {
 export class Example {
   myCustomText = "This resolver has class inbound";
 
-  @Slash("hello")
+  @Slash({ name: "hello" })
   hello(
-    @SlashOption("user", { type: ApplicationCommandOptionType.User })
+    @SlashOption({ name: "user", type: ApplicationCommandOptionType.User })
     user: GuildMember | User,
     interaction: CommandInteraction
   ): void {
     interaction.reply(`${user}`);
   }
 
-  @Slash("role")
+  @Slash({ name: "role" })
   role(
-    @SlashOption("role", { type: ApplicationCommandOptionType.Role })
+    @SlashOption({ name: "role", type: ApplicationCommandOptionType.Role })
     role: Role,
     interaction: CommandInteraction
   ): void {
     interaction.reply(`${role}`);
   }
 
-  @Slash("channel")
+  @Slash({ name: "channel" })
   channel(
-    @SlashOption("channel", { type: ApplicationCommandOptionType.Channel })
+    @SlashOption({
+      name: "channel",
+      type: ApplicationCommandOptionType.Channel,
+    })
     channel: Channel,
     interaction: CommandInteraction
   ): void {
     interaction.reply(`${channel}`);
   }
 
-  @Slash("role-or-user")
+  @Slash({ name: "role-or-user" })
   roleOrUser(
-    @SlashOption("mention", { type: ApplicationCommandOptionType.Mentionable })
+    @SlashOption({
+      name: "mention",
+      type: ApplicationCommandOptionType.Mentionable,
+    })
     roleOrUser: GuildMember | User | Role,
     interaction: CommandInteraction
   ): void {
     interaction.reply(`${roleOrUser}`);
   }
 
-  @Slash("autocomplete")
+  @Slash({ name: "autocomplete" })
   autocomplete(
-    @SlashOption("option-a", {
+    @SlashOption({
       autocomplete: true,
+      name: "option-a",
       type: ApplicationCommandOptionType.String,
     })
     searchText: string,
-    @SlashOption("option-b", {
+    @SlashOption({
       autocomplete: function (
         this: Example,
         interaction: AutocompleteInteraction
@@ -83,10 +90,11 @@ export class Example {
           { name: "option d", value: "c" },
         ]);
       },
+      name: "option-b",
       type: ApplicationCommandOptionType.String,
     })
     searchText2: string,
-    @SlashOption("option-c", {
+    @SlashOption({
       autocomplete: (interaction: AutocompleteInteraction) => {
         // arrow function does not have this, so class reference is not available
         interaction.respond([
@@ -94,6 +102,7 @@ export class Example {
           { name: "option f", value: "f" },
         ]);
       },
+      name: "option-c",
       type: ApplicationCommandOptionType.String,
     })
     searchText3: string,
@@ -114,7 +123,7 @@ export class Example {
     }
   }
 
-  @Slash("test-btn")
+  @Slash({ name: "test-btn" })
   testBtn(interaction: CommandInteraction): void {
     const btn = new ButtonBuilder();
     btn.setLabel("Test");

--- a/packages/discordx/examples/slash/commands/group.ts
+++ b/packages/discordx/examples/slash/commands/group.ts
@@ -8,15 +8,16 @@ import { Discord, Slash, SlashGroup, SlashOption } from "../../../src/index.js";
 @SlashGroup({ name: "maths", root: "testing" })
 @SlashGroup({ name: "text", root: "testing" })
 export class Example {
-  @Slash("voice-channel")
+  @Slash({ name: "voice-channel" })
   @SlashGroup("maths", "testing")
   voiceChannel(
-    @SlashOption("channel", {
+    @SlashOption({
       channelTypes: [
         ChannelType.GuildCategory,
         ChannelType.GuildVoice,
         ChannelType.GuildText,
       ],
+      name: "channel",
       type: ApplicationCommandOptionType.Channel,
     })
     roleOrUser: GuildMember | User | Role,
@@ -25,14 +26,15 @@ export class Example {
     interaction.reply(`${roleOrUser}`);
   }
 
-  @Slash("voice-channel-x")
+  @Slash({ name: "voice-channel-x" })
   voiceChannelX(
-    @SlashOption("channel", {
+    @SlashOption({
       channelTypes: [
         ChannelType.GuildCategory,
         ChannelType.GuildVoice,
         ChannelType.GuildText,
       ],
+      name: "channel",
       type: ApplicationCommandOptionType.Channel,
     })
     roleOrUser: GuildMember | User | Role,
@@ -41,21 +43,21 @@ export class Example {
     interaction.reply(`${roleOrUser}`);
   }
 
-  @Slash("add")
+  @Slash({ name: "add" })
   @SlashGroup("maths", "testing")
   add(
-    @SlashOption("x", { description: "x value" }) x: number,
-    @SlashOption("y", { description: "y value" }) y: number,
+    @SlashOption({ description: "x value", name: "x" }) x: number,
+    @SlashOption({ description: "y value", name: "y" }) y: number,
     interaction: CommandInteraction
   ): void {
     interaction.reply(String(x + y));
   }
 
-  @Slash("multiply")
+  @Slash({ name: "multiply" })
   @SlashGroup("maths", "testing")
   multiply(
-    @SlashOption("x", { description: "x value" }) x: number,
-    @SlashOption("y", { description: "y value" }) y: number,
+    @SlashOption({ description: "x value", name: "x" }) x: number,
+    @SlashOption({ description: "y value", name: "y" }) y: number,
     interaction: CommandInteraction
   ): void {
     interaction.reply(String(x * y));

--- a/packages/discordx/examples/slash/commands/minMax.ts
+++ b/packages/discordx/examples/slash/commands/minMax.ts
@@ -5,10 +5,11 @@ import { Discord, Slash, SlashOption } from "../../../src/index.js";
 
 @Discord()
 export class MinMaxExample {
-  @Slash("minmax-min")
+  @Slash({ name: "minmax-min" })
   min(
-    @SlashOption("value", {
+    @SlashOption({
       minValue: 5,
+      name: "value",
       type: ApplicationCommandOptionType.Number,
     })
     input: number,
@@ -17,10 +18,11 @@ export class MinMaxExample {
     interaction.reply(`${input}`);
   }
 
-  @Slash("minmax-max")
+  @Slash({ name: "minmax-max" })
   max(
-    @SlashOption("value", {
+    @SlashOption({
       maxValue: 5,
+      name: "value",
       type: ApplicationCommandOptionType.Number,
     })
     input: number,
@@ -29,11 +31,12 @@ export class MinMaxExample {
     interaction.reply(`${input}`);
   }
 
-  @Slash("minmax-both")
+  @Slash({ name: "minmax-both" })
   MinMax(
-    @SlashOption("value", {
+    @SlashOption({
       maxValue: 15,
       minValue: 5,
+      name: "value",
       type: ApplicationCommandOptionType.Number,
     })
     input: number,

--- a/packages/discordx/src/decorators/classes/DReaction.ts
+++ b/packages/discordx/src/decorators/classes/DReaction.ts
@@ -90,7 +90,7 @@ export class DReaction extends Method {
     this._guilds = data.guilds ?? [];
     this._botIds = data.botIds ?? [];
     this._aliases = data.aliases ?? [];
-    this._remove = data.remove ?? true;
+    this._remove = data.remove ?? false;
     this._partial = data.partial ?? false;
   }
 

--- a/packages/discordx/src/decorators/decorators/Bot.ts
+++ b/packages/discordx/src/decorators/decorators/Bot.ts
@@ -38,6 +38,17 @@ export function Bot<T extends string>(botId: NotEmpty<T>): ClassMethodDecorator;
  */
 export function Bot(...botIds: string[]): ClassMethodDecorator;
 
+/**
+ * Execute your application button, event, select menu, simple command, slash by defined bot
+ * when multiple bots are running simultaneously
+ *
+ * @param botIds - Multiple bot identifiers
+ * ___
+ *
+ * [View Documentation](https://discord-ts.js.org/docs/decorators/general/bot)
+ *
+ * @category Decorator
+ */
 export function Bot(...botIds: string[]): ClassMethodDecorator {
   return function <T>(
     target: Record<string, T>,

--- a/packages/discordx/src/decorators/decorators/ButtonComponent.ts
+++ b/packages/discordx/src/decorators/decorators/ButtonComponent.ts
@@ -1,8 +1,7 @@
 import type { MethodDecoratorEx } from "@discordx/internal";
 
-import type { IGuild } from "../../index.js";
 import { ComponentType, DComponent, MetadataStorage } from "../../index.js";
-import type { NotEmpty } from "../../types/index.js";
+import type { ComponentOptions } from "../../types/index.js";
 
 /**
  * Interact with buttons with a defined identifier
@@ -17,7 +16,7 @@ export function ButtonComponent(): MethodDecoratorEx;
 /**
  * Interact with buttons with a defined identifier
  *
- * @param id - Button identifier
+ * @param options - Component options
  * ___
  *
  * [View Documentation](https://discord-ts.js.org/docs/decorators/gui/button-component)
@@ -25,62 +24,15 @@ export function ButtonComponent(): MethodDecoratorEx;
  * @category Decorator
  */
 export function ButtonComponent<T extends string>(
-  id: NotEmpty<T>
+  options?: ComponentOptions<T>
 ): MethodDecoratorEx;
 
-/**
- * Interact with buttons with a defined identifier
- *
- * @param id - Button identifier
- * ___
- *
- * [View Documentation](https://discord-ts.js.org/docs/decorators/gui/button-component)
- *
- * @category Decorator
- */
-export function ButtonComponent(id: RegExp): MethodDecoratorEx;
-
-/**
- * Interact with buttons with a defined identifier
- *
- * @param id - Button identifier
- * @param options - Options for the button component
- * ___
- *
- * [View Documentation](https://discord-ts.js.org/docs/decorators/gui/button-component)
- *
- * @category Decorator
- */
-export function ButtonComponent<T extends string>(
-  id: NotEmpty<T>,
-  options: { botIds?: string[]; guilds?: IGuild[] }
-): MethodDecoratorEx;
-
-/**
- * Interact with buttons with a defined identifier
- *
- * @param id - Button identifier
- * @param options - Options for the button component
- * ___
- *
- * [View Documentation](https://discord-ts.js.org/docs/decorators/gui/button-component)
- *
- * @category Decorator
- */
-export function ButtonComponent(
-  id: RegExp,
-  options: { botIds?: string[]; guilds?: IGuild[] }
-): MethodDecoratorEx;
-
-export function ButtonComponent(
-  id?: string | RegExp,
-  options?: { botIds?: string[]; guilds?: IGuild[] }
-): MethodDecoratorEx {
+export function ButtonComponent(options?: ComponentOptions): MethodDecoratorEx {
   return function <T>(target: Record<string, T>, key: string) {
     const button = DComponent.create({
       botIds: options?.botIds,
       guilds: options?.guilds,
-      id: id ?? key,
+      id: options?.id ?? key,
       type: ComponentType.Button,
     }).decorate(target.constructor, key, target[key]);
     MetadataStorage.instance.addComponentButton(button);

--- a/packages/discordx/src/decorators/decorators/ButtonComponent.ts
+++ b/packages/discordx/src/decorators/decorators/ButtonComponent.ts
@@ -24,9 +24,29 @@ export function ButtonComponent(): MethodDecoratorEx;
  * @category Decorator
  */
 export function ButtonComponent<T extends string>(
-  options?: ComponentOptions<T>
+  options: ComponentOptions<T>
 ): MethodDecoratorEx;
 
+/**
+ * Interact with buttons with a defined identifier
+ *
+ * @param options - Component options
+ * ___
+ *
+ * [View Documentation](https://discord-ts.js.org/docs/decorators/gui/button-component)
+ *
+ * @category Decorator
+ */
+/**
+ * Interact with buttons with a defined identifier
+ *
+ * @param options - Component options
+ * ___
+ *
+ * [View Documentation](https://discord-ts.js.org/docs/decorators/gui/button-component)
+ *
+ * @category Decorator
+ */
 export function ButtonComponent(options?: ComponentOptions): MethodDecoratorEx {
   return function <T>(target: Record<string, T>, key: string) {
     const button = DComponent.create({

--- a/packages/discordx/src/decorators/decorators/ContextMenu.ts
+++ b/packages/discordx/src/decorators/decorators/ContextMenu.ts
@@ -15,18 +15,9 @@ import type { NotEmpty } from "../../types/index.js";
  *
  * @category Decorator
  */
-export function ContextMenu<T extends string>(
+export function ContextMenu<TName extends string>(
   options: Omit<
-    ApplicationCommandOptions<NotEmpty<T>> & {
-      type: Exclude<ApplicationCommandType, ApplicationCommandType.ChatInput>;
-    },
-    "description"
-  >
-): MethodDecoratorEx;
-
-export function ContextMenu(
-  options: Omit<
-    ApplicationCommandOptions & {
+    ApplicationCommandOptions<NotEmpty<TName>> & {
       type: Exclude<ApplicationCommandType, ApplicationCommandType.ChatInput>;
     },
     "description"

--- a/packages/discordx/src/decorators/decorators/ContextMenu.ts
+++ b/packages/discordx/src/decorators/decorators/ContextMenu.ts
@@ -8,22 +8,7 @@ import type { NotEmpty } from "../../types/index.js";
 /**
  * Interact with context menu with a defined identifier
  *
- * @param type - Context menu type
- * ___
- *
- * [View Documentation](https://discord-ts.js.org/docs/decorators/gui/context-menu)
- *
- * @category Decorator
- */
-export function ContextMenu(
-  type: Exclude<ApplicationCommandType, ApplicationCommandType.ChatInput>
-): MethodDecoratorEx;
-
-/**
- * Interact with context menu with a defined identifier
- *
- * @param type - Context menu type
- * @param name - Context menu name
+ * @param options - Application command options
  * ___
  *
  * [View Documentation](https://discord-ts.js.org/docs/decorators/gui/context-menu)
@@ -31,44 +16,31 @@ export function ContextMenu(
  * @category Decorator
  */
 export function ContextMenu<T extends string>(
-  type: Exclude<ApplicationCommandType, ApplicationCommandType.ChatInput>,
-  name: NotEmpty<T>
-): MethodDecoratorEx;
-
-/**
- * Interact with context menu with a defined identifier
- *
- * @param type - Context menu type
- * @param name - Context menu name
- * @param options - Options for the context menu
- * ___
- *
- * [View Documentation](https://discord-ts.js.org/docs/decorators/gui/context-menu)
- *
- * @category Decorator
- */
-export function ContextMenu<T extends string>(
-  type: Exclude<ApplicationCommandType, ApplicationCommandType.ChatInput>,
-  name: NotEmpty<T>,
-  options: Omit<ApplicationCommandOptions, "description">
+  options: Omit<
+    ApplicationCommandOptions<NotEmpty<T>> & {
+      type: Exclude<ApplicationCommandType, ApplicationCommandType.ChatInput>;
+    },
+    "description"
+  >
 ): MethodDecoratorEx;
 
 export function ContextMenu(
-  type: Exclude<ApplicationCommandType, ApplicationCommandType.ChatInput>,
-  name?: string,
-  options?: Omit<ApplicationCommandOptions, "description">
+  options: Omit<
+    ApplicationCommandOptions & {
+      type: Exclude<ApplicationCommandType, ApplicationCommandType.ChatInput>;
+    },
+    "description"
+  >
 ): MethodDecoratorEx {
   return function <T>(target: Record<string, T>, key: string) {
-    name = name ?? key;
-
     const applicationCommand = DApplicationCommand.create({
-      botIds: options?.botIds,
-      guilds: options?.guilds,
-      name: name,
-      type: type,
+      botIds: options.botIds,
+      guilds: options.guilds,
+      name: options.name ?? key,
+      type: options.type,
     }).decorate(target.constructor, key, target[key]);
 
-    if (type === ApplicationCommandType.Message) {
+    if (options.type === ApplicationCommandType.Message) {
       MetadataStorage.instance.addApplicationCommandMessage(applicationCommand);
     } else {
       MetadataStorage.instance.addApplicationCommandUser(applicationCommand);

--- a/packages/discordx/src/decorators/decorators/Guild.ts
+++ b/packages/discordx/src/decorators/decorators/Guild.ts
@@ -35,6 +35,16 @@ export function Guild(guildId: IGuild): ClassMethodDecorator;
  */
 export function Guild(...guildIds: IGuild[]): ClassMethodDecorator;
 
+/**
+ * Use buttons, events, select menus, simple commands and slashes for a defined guild only
+ *
+ * @param guildIds - Guild identifiers
+ * ___
+ *
+ * [View Documentation](https://discord-ts.js.org/docs/decorators/general/guild)
+ *
+ * @category Decorator
+ */
 export function Guild(...guildIds: IGuild[]): ClassMethodDecorator {
   return function <T>(
     target: Record<string, T>,

--- a/packages/discordx/src/decorators/decorators/ModalComponent.ts
+++ b/packages/discordx/src/decorators/decorators/ModalComponent.ts
@@ -1,45 +1,38 @@
 import type { MethodDecoratorEx } from "@discordx/internal";
 
-import type { IGuild } from "../../index.js";
+import type { ComponentOptions } from "../../index.js";
 import { ComponentType, DComponent, MetadataStorage } from "../../index.js";
 
 /**
  * Create modal interaction handler
- *
- * @param id - Custom identifier
  * ___
  *
  * [View Documentation](https://discord-ts.js.org/docs/decorators/gui/modal-component)
  *
  * @category Decorator
  */
-export function ModalComponent(id?: string | RegExp): MethodDecoratorEx;
+export function ModalComponent(): MethodDecoratorEx;
 
 /**
  * Create modal interaction handler
  *
- * @param id - Custom identifier
- * @param options - Options
+ * @param options - Component options
  * ___
  *
  * [View Documentation](https://discord-ts.js.org/docs/decorators/gui/modal-component)
  *
  * @category Decorator
  */
-export function ModalComponent(
-  id: string | RegExp,
-  options?: { botIds?: string[]; guilds?: IGuild[] }
+export function ModalComponent<T extends string>(
+  options?: ComponentOptions<T>
 ): MethodDecoratorEx;
 
-export function ModalComponent(
-  id?: string | RegExp,
-  params?: { botIds?: string[]; guilds?: IGuild[] }
-): MethodDecoratorEx {
+export function ModalComponent(options?: ComponentOptions): MethodDecoratorEx {
   return function <T>(target: Record<string, T>, key: string) {
     const button = DComponent.create({
-      botIds: params?.botIds,
-      guilds: params?.guilds,
-      id: id ?? key,
+      botIds: options?.botIds,
+      guilds: options?.guilds,
+      id: options?.id ?? key,
       type: ComponentType.Modal,
     }).decorate(target.constructor, key, target[key]);
 

--- a/packages/discordx/src/decorators/decorators/ModalComponent.ts
+++ b/packages/discordx/src/decorators/decorators/ModalComponent.ts
@@ -24,9 +24,19 @@ export function ModalComponent(): MethodDecoratorEx;
  * @category Decorator
  */
 export function ModalComponent<T extends string>(
-  options?: ComponentOptions<T>
+  options: ComponentOptions<T>
 ): MethodDecoratorEx;
 
+/**
+ * Create modal interaction handler
+ *
+ * @param options - Component options
+ * ___
+ *
+ * [View Documentation](https://discord-ts.js.org/docs/decorators/gui/modal-component)
+ *
+ * @category Decorator
+ */
 export function ModalComponent(options?: ComponentOptions): MethodDecoratorEx {
   return function <T>(target: Record<string, T>, key: string) {
     const button = DComponent.create({

--- a/packages/discordx/src/decorators/decorators/On.ts
+++ b/packages/discordx/src/decorators/decorators/On.ts
@@ -1,40 +1,32 @@
 import type { MethodDecoratorEx } from "@discordx/internal";
+import type { ClientEvents } from "discord.js";
 
-import type { DiscordEvents, EventOptions } from "../../index.js";
+import type { EventOptions } from "../../index.js";
 import { DOn, MetadataStorage } from "../../index.js";
 
 /**
  * Handle discord events with a defined handler
- *
- * @param event - Event name
  * ___
  *
  * [View Documentation](https://discord-ts.js.org/docs/decorators/general/on)
  *
  * @category Decorator
  */
-export function On(event: DiscordEvents): MethodDecoratorEx;
+export function On(): MethodDecoratorEx;
 
 /**
  * Handle discord events with a defined handler
  *
- * @param event - Event name
- * @param options - Event parameters
+ * @param options - Event options
  * ___
  *
  * [View Documentation](https://discord-ts.js.org/docs/decorators/general/on)
  *
  * @category Decorator
  */
-export function On(
-  event: DiscordEvents,
-  options?: EventOptions
-): MethodDecoratorEx;
+export function On(options?: EventOptions): MethodDecoratorEx;
 
-export function On(
-  event: DiscordEvents,
-  options?: EventOptions
-): MethodDecoratorEx {
+export function On(options?: EventOptions): MethodDecoratorEx {
   return function <T>(
     target: Record<string, T>,
     key: string,
@@ -43,7 +35,7 @@ export function On(
     const clazz = target as unknown as new () => unknown;
     const on = DOn.create({
       botIds: options?.botIds,
-      event,
+      event: options?.event ?? (key as keyof ClientEvents),
       once: false,
     }).decorate(clazz.constructor, key, descriptor?.value);
 

--- a/packages/discordx/src/decorators/decorators/On.ts
+++ b/packages/discordx/src/decorators/decorators/On.ts
@@ -24,8 +24,18 @@ export function On(): MethodDecoratorEx;
  *
  * @category Decorator
  */
-export function On(options?: EventOptions): MethodDecoratorEx;
+export function On(options: EventOptions): MethodDecoratorEx;
 
+/**
+ * Handle discord events with a defined handler
+ *
+ * @param options - Event options
+ * ___
+ *
+ * [View Documentation](https://discord-ts.js.org/docs/decorators/general/on)
+ *
+ * @category Decorator
+ */
 export function On(options?: EventOptions): MethodDecoratorEx {
   return function <T>(
     target: Record<string, T>,

--- a/packages/discordx/src/decorators/decorators/Once.ts
+++ b/packages/discordx/src/decorators/decorators/Once.ts
@@ -1,24 +1,22 @@
 import type { MethodDecoratorEx } from "@discordx/internal";
+import type { ClientEvents } from "discord.js";
 
-import type { DiscordEvents, EventOptions } from "../../index.js";
+import type { EventOptions } from "../../index.js";
 import { DOn, MetadataStorage } from "../../index.js";
 
 /**
  * Handle discord events once only with a defined handler
- *
- * @param event - Event name
  * ___
  *
  * [View Documentation](https://discord-ts.js.org/docs/decorators/general/once)
  *
  * @category Decorator
  */
-export function Once(event: DiscordEvents): MethodDecoratorEx;
+export function Once(): MethodDecoratorEx;
 
 /**
  * Handle discord events once only with a defined handler
  *
- * @param event - Event name
  * @param options - Event parameters
  * ___
  *
@@ -26,15 +24,9 @@ export function Once(event: DiscordEvents): MethodDecoratorEx;
  *
  * @category Decorator
  */
-export function Once(
-  event: DiscordEvents,
-  options?: EventOptions
-): MethodDecoratorEx;
+export function Once(options?: EventOptions): MethodDecoratorEx;
 
-export function Once(
-  event: DiscordEvents,
-  options?: EventOptions
-): MethodDecoratorEx {
+export function Once(options?: EventOptions): MethodDecoratorEx {
   return function <T>(
     target: Record<string, T>,
     key: string,
@@ -43,7 +35,7 @@ export function Once(
     const clazz = target as unknown as new () => unknown;
     const on = DOn.create({
       botIds: options?.botIds,
-      event,
+      event: options?.event ?? (key as keyof ClientEvents),
       once: true,
     }).decorate(clazz.constructor, key, descriptor.value);
 

--- a/packages/discordx/src/decorators/decorators/Once.ts
+++ b/packages/discordx/src/decorators/decorators/Once.ts
@@ -24,8 +24,18 @@ export function Once(): MethodDecoratorEx;
  *
  * @category Decorator
  */
-export function Once(options?: EventOptions): MethodDecoratorEx;
+export function Once(options: EventOptions): MethodDecoratorEx;
 
+/**
+ * Handle discord events once only with a defined handler
+ *
+ * @param options - Event parameters
+ * ___
+ *
+ * [View Documentation](https://discord-ts.js.org/docs/decorators/general/once)
+ *
+ * @category Decorator
+ */
 export function Once(options?: EventOptions): MethodDecoratorEx {
   return function <T>(
     target: Record<string, T>,

--- a/packages/discordx/src/decorators/decorators/Reaction.ts
+++ b/packages/discordx/src/decorators/decorators/Reaction.ts
@@ -1,13 +1,23 @@
 import type { MethodDecoratorEx } from "@discordx/internal";
 
-import type { NotEmpty, ReactionOptions } from "../../index.js";
+import type { ReactionOptions } from "../../index.js";
 import { MetadataStorage } from "../../index.js";
 import { DReaction } from "../classes/DReaction.js";
 
 /**
  * Handle a reaction with a specified emoji
+ * ___
  *
- * @param emoji - Emoji, in the form of a Unicode string, custom name, or Snowflake.
+ * [View Documentation](https://discord-ts.js.org/docs/decorators/general/reaction)
+ *
+ * @category Decorator
+ */
+export function Reaction(): MethodDecoratorEx;
+
+/**
+ * Handle a reaction with a specified emoji (a Unicode string, custom name, or Snowflake)
+ *
+ * @param options - reaction options
  * ___
  *
  * [View Documentation](https://discord-ts.js.org/docs/decorators/general/reaction)
@@ -15,45 +25,17 @@ import { DReaction } from "../classes/DReaction.js";
  * @category Decorator
  */
 export function Reaction<T extends string>(
-  emoji: NotEmpty<T>
+  options?: ReactionOptions<T>
 ): MethodDecoratorEx;
 
-/**
- * Handle a reaction with a specified emoji
- *
- * @param emoji - Emoji, in the form of a Unicode string, custom name, or Snowflake.
- * ___
- *
- * [View Documentation](https://discord-ts.js.org/docs/decorators/general/reaction)
- *
- * @category Decorator
- */
-export function Reaction<T extends string>(
-  emoji: NotEmpty<T>,
-  options: ReactionOptions
-): MethodDecoratorEx;
-
-/**
- * Handle a reaction with a specified emoji
- *
- * @param emoji - Emoji, in the form of a Unicode string, custom name, or Snowflake.
- * ___
- *
- * [View Documentation](https://discord-ts.js.org/docs/decorators/general/reaction)
- *
- * @category Decorator
- */
-export function Reaction(
-  emoji: string,
-  options?: ReactionOptions
-): MethodDecoratorEx {
+export function Reaction(options?: ReactionOptions): MethodDecoratorEx {
   return function <T>(target: Record<string, T>, key: string) {
     const react = DReaction.create({
       aliases: options?.aliases,
       botIds: options?.botIds,
       description: options?.description,
       directMessage: options?.directMessage,
-      emoji: emoji,
+      emoji: options?.emoji ?? key,
       guilds: options?.guilds,
       partial: options?.partial,
       remove: options?.remove,

--- a/packages/discordx/src/decorators/decorators/Reaction.ts
+++ b/packages/discordx/src/decorators/decorators/Reaction.ts
@@ -25,9 +25,19 @@ export function Reaction(): MethodDecoratorEx;
  * @category Decorator
  */
 export function Reaction<T extends string>(
-  options?: ReactionOptions<T>
+  options: ReactionOptions<T>
 ): MethodDecoratorEx;
 
+/**
+ * Handle a reaction with a specified emoji (a Unicode string, custom name, or Snowflake)
+ *
+ * @param options - reaction options
+ * ___
+ *
+ * [View Documentation](https://discord-ts.js.org/docs/decorators/general/reaction)
+ *
+ * @category Decorator
+ */
 export function Reaction(options?: ReactionOptions): MethodDecoratorEx {
   return function <T>(target: Record<string, T>, key: string) {
     const react = DReaction.create({

--- a/packages/discordx/src/decorators/decorators/SelectMenuComponent.ts
+++ b/packages/discordx/src/decorators/decorators/SelectMenuComponent.ts
@@ -24,9 +24,19 @@ export function SelectMenuComponent(): MethodDecoratorEx;
  * @category Decorator
  */
 export function SelectMenuComponent<T extends string>(
-  options?: ComponentOptions<T>
+  options: ComponentOptions<T>
 ): MethodDecoratorEx;
 
+/**
+ * Interact with select menu with a defined identifier
+ *
+ * @param options - Component options
+ * ___
+ *
+ * [View Documentation](https://discord-ts.js.org/docs/decorators/gui/select-menu-component)
+ *
+ * @category Decorator
+ */
 export function SelectMenuComponent(
   options?: ComponentOptions
 ): MethodDecoratorEx {

--- a/packages/discordx/src/decorators/decorators/SelectMenuComponent.ts
+++ b/packages/discordx/src/decorators/decorators/SelectMenuComponent.ts
@@ -1,8 +1,7 @@
 import type { MethodDecoratorEx } from "@discordx/internal";
 
-import type { IGuild } from "../../index.js";
 import { ComponentType, DComponent, MetadataStorage } from "../../index.js";
-import type { NotEmpty } from "../../types/index.js";
+import type { ComponentOptions } from "../../types/index.js";
 
 /**
  * Interact with select menu with a defined identifier
@@ -17,7 +16,7 @@ export function SelectMenuComponent(): MethodDecoratorEx;
 /**
  * Interact with select menu with a defined identifier
  *
- * @param id - Select menu identifier
+ * @param options - Component options
  * ___
  *
  * [View Documentation](https://discord-ts.js.org/docs/decorators/gui/select-menu-component)
@@ -25,62 +24,17 @@ export function SelectMenuComponent(): MethodDecoratorEx;
  * @category Decorator
  */
 export function SelectMenuComponent<T extends string>(
-  id: NotEmpty<T>
-): MethodDecoratorEx;
-
-/**
- * Interact with select menu with a defined identifier
- *
- * @param id - Select menu identifier
- * ___
- *
- * [View Documentation](https://discord-ts.js.org/docs/decorators/gui/select-menu-component)
- *
- * @category Decorator
- */
-export function SelectMenuComponent(id: RegExp): MethodDecoratorEx;
-
-/**
- * Interact with select menu with a defined identifier
- *
- * @param id - Select menu identifier
- * @param options - Options for the select menu
- * ___
- *
- * [View Documentation](https://discord-ts.js.org/docs/decorators/gui/select-menu-component)
- *
- * @category Decorator
- */
-export function SelectMenuComponent<T extends string>(
-  id: NotEmpty<T>,
-  options: { botIds?: string[]; guilds?: IGuild[] }
-): MethodDecoratorEx;
-
-/**
- * Interact with select menu with a defined identifier
- *
- * @param id - Select menu identifier
- * @param options - Options for the select menu
- * ___
- *
- * [View Documentation](https://discord-ts.js.org/docs/decorators/gui/select-menu-component)
- *
- * @category Decorator
- */
-export function SelectMenuComponent(
-  id: RegExp,
-  options: { botIds?: string[]; guilds?: IGuild[] }
+  options?: ComponentOptions<T>
 ): MethodDecoratorEx;
 
 export function SelectMenuComponent(
-  id?: string | RegExp,
-  options?: { botIds?: string[]; guilds?: IGuild[] }
+  options?: ComponentOptions
 ): MethodDecoratorEx {
   return function <T>(target: Record<string, T>, key: string) {
     const button = DComponent.create({
       botIds: options?.botIds,
       guilds: options?.guilds,
-      id: id ?? key,
+      id: options?.id ?? key,
       type: ComponentType.SelectMenu,
     }).decorate(target.constructor, key, target[key]);
 

--- a/packages/discordx/src/decorators/decorators/SimpleCommand.ts
+++ b/packages/discordx/src/decorators/decorators/SimpleCommand.ts
@@ -1,6 +1,6 @@
 import type { MethodDecoratorEx } from "@discordx/internal";
 
-import type { NotEmpty, SimpleCommandOptions } from "../../index.js";
+import type { SimpleCommandOptions } from "../../index.js";
 import { DSimpleCommand, MetadataStorage } from "../../index.js";
 
 /**
@@ -20,23 +20,6 @@ export function SimpleCommand(): MethodDecoratorEx;
  *
  * Example ``!hello world``
  *
- * @param name - Command name
- * ___
- *
- * [View Documentation](https://discord-ts.js.org/docs/decorators/commands/simple-command)
- *
- * @category Decorator
- */
-export function SimpleCommand<T extends string>(
-  name: NotEmpty<T>
-): MethodDecoratorEx;
-
-/**
- * Handle a simple command with a defined name
- *
- * Example ``!hello world``
- *
- * @param name - Command name
  * @param options - Command options
  * ___
  *
@@ -45,17 +28,13 @@ export function SimpleCommand<T extends string>(
  * @category Decorator
  */
 export function SimpleCommand<T extends string>(
-  name: NotEmpty<T>,
-  options: SimpleCommandOptions
+  options?: SimpleCommandOptions<T>
 ): MethodDecoratorEx;
 
 export function SimpleCommand(
-  name?: string,
   options?: SimpleCommandOptions
 ): MethodDecoratorEx {
   return function <T>(target: Record<string, T>, key: string) {
-    name = name ?? key;
-
     const cmd = DSimpleCommand.create({
       aliases: options?.aliases,
       argSplitter: options?.argSplitter,
@@ -63,7 +42,7 @@ export function SimpleCommand(
       description: options?.description,
       directMessage: options?.directMessage,
       guilds: options?.guilds,
-      name: name,
+      name: options?.name ?? key,
       prefix: options?.prefix,
     }).decorate(target.constructor, key, target[key]);
 

--- a/packages/discordx/src/decorators/decorators/SimpleCommand.ts
+++ b/packages/discordx/src/decorators/decorators/SimpleCommand.ts
@@ -28,9 +28,21 @@ export function SimpleCommand(): MethodDecoratorEx;
  * @category Decorator
  */
 export function SimpleCommand<T extends string>(
-  options?: SimpleCommandOptions<T>
+  options: SimpleCommandOptions<T>
 ): MethodDecoratorEx;
 
+/**
+ * Handle a simple command with a defined name
+ *
+ * Example ``!hello world``
+ *
+ * @param options - Command options
+ * ___
+ *
+ * [View Documentation](https://discord-ts.js.org/docs/decorators/commands/simple-command)
+ *
+ * @category Decorator
+ */
 export function SimpleCommand(
   options?: SimpleCommandOptions
 ): MethodDecoratorEx {

--- a/packages/discordx/src/decorators/decorators/SimpleCommandOption.ts
+++ b/packages/discordx/src/decorators/decorators/SimpleCommandOption.ts
@@ -19,12 +19,8 @@ import {
  *
  * @category Decorator
  */
-export function SimpleCommandOption<T extends string>(
-  options: SimpleCommandOptionOptions<T>
-): ParameterDecoratorEx;
-
-export function SimpleCommandOption(
-  options: SimpleCommandOptionOptions
+export function SimpleCommandOption<TName extends string>(
+  options: SimpleCommandOptionOptions<TName>
 ): ParameterDecoratorEx {
   function getType(type: string): SimpleCommandOptionType {
     switch (type) {

--- a/packages/discordx/src/decorators/decorators/SimpleCommandOption.ts
+++ b/packages/discordx/src/decorators/decorators/SimpleCommandOption.ts
@@ -1,7 +1,7 @@
 import type { ParameterDecoratorEx } from "@discordx/internal";
 import { Modifier } from "@discordx/internal";
 
-import type { VerifyName } from "../../index.js";
+import type { SimpleCommandOptionOptions } from "../../index.js";
 import {
   DSimpleCommand,
   DSimpleCommandOption,
@@ -12,7 +12,7 @@ import {
 /**
  * Add a simple command option
  *
- * @param name - Option name
+ * @param options - Command option options
  * ___
  *
  * [View Documentation](https://discord-ts.js.org/docs/decorators/commands/simple-command-option)
@@ -20,28 +20,11 @@ import {
  * @category Decorator
  */
 export function SimpleCommandOption<T extends string>(
-  name: VerifyName<T>
-): ParameterDecoratorEx;
-
-/**
- * Add a simple command option
- *
- * @param name - Option name
- * @param options - Additional options
- * ___
- *
- * [View Documentation](https://discord-ts.js.org/docs/decorators/commands/simple-command-option)
- *
- * @category Decorator
- */
-export function SimpleCommandOption<T extends string>(
-  name: VerifyName<T>,
-  options?: { description?: string; type?: SimpleCommandOptionType }
+  options: SimpleCommandOptionOptions<T>
 ): ParameterDecoratorEx;
 
 export function SimpleCommandOption(
-  name: string,
-  options?: { description?: string; type?: SimpleCommandOptionType }
+  options: SimpleCommandOptionOptions
 ): ParameterDecoratorEx {
   function getType(type: string): SimpleCommandOptionType {
     switch (type) {
@@ -87,8 +70,8 @@ export function SimpleCommandOption(
     const type: SimpleCommandOptionType = options?.type ?? getType(dType);
 
     const option = DSimpleCommandOption.create({
-      description: options?.description,
-      name,
+      description: options.description,
+      name: options.name,
       type,
     }).decorate(
       target.constructor,

--- a/packages/discordx/src/decorators/decorators/Slash.ts
+++ b/packages/discordx/src/decorators/decorators/Slash.ts
@@ -7,21 +7,6 @@ import { DApplicationCommand, MetadataStorage } from "../../index.js";
 /**
  * Handle a slash command with a defined name
  *
- * @param name - Slash name
- * ___
- *
- * [View Documentation](https://discord-ts.js.org/docs/decorators/commands/slash)
- *
- * @category Decorator -
- */
-export function Slash<T extends string>(
-  name?: VerifyName<T>
-): MethodDecoratorEx;
-
-/**
- * Handle a slash command with a defined name
- *
- * @param name - Slash name
  * @param options - Slash options
  * ___
  *
@@ -30,17 +15,11 @@ export function Slash<T extends string>(
  * @category Decorator
  */
 export function Slash<T extends string>(
-  name?: VerifyName<T>,
-  options?: ApplicationCommandOptions
+  options?: ApplicationCommandOptions<VerifyName<T>>
 ): MethodDecoratorEx;
 
-export function Slash(
-  name?: string,
-  options?: ApplicationCommandOptions
-): MethodDecoratorEx {
+export function Slash(options?: ApplicationCommandOptions): MethodDecoratorEx {
   return function <T>(target: Record<string, T>, key: string) {
-    name = name ?? key;
-
     const applicationCommand = DApplicationCommand.create({
       botIds: options?.botIds,
       defaultMemberPermissions: options?.defaultMemberPermissions,
@@ -48,7 +27,7 @@ export function Slash(
       descriptionLocalizations: options?.descriptionLocalizations,
       dmPermission: options?.dmPermission,
       guilds: options?.guilds,
-      name: name,
+      name: options?.name ?? key,
       nameLocalizations: options?.nameLocalizations,
       type: ApplicationCommandType.ChatInput,
     }).decorate(target.constructor, key, target[key]);

--- a/packages/discordx/src/decorators/decorators/Slash.ts
+++ b/packages/discordx/src/decorators/decorators/Slash.ts
@@ -25,9 +25,19 @@ export function Slash(): MethodDecoratorEx;
  * @category Decorator
  */
 export function Slash<T extends string>(
-  options?: ApplicationCommandOptions<VerifyName<T>>
+  options: ApplicationCommandOptions<VerifyName<T>>
 ): MethodDecoratorEx;
 
+/**
+ * Handle a slash command with a defined name
+ *
+ * @param options - Application command options
+ * ___
+ *
+ * [View Documentation](https://discord-ts.js.org/docs/decorators/commands/slash)
+ *
+ * @category Decorator
+ */
 export function Slash(options?: ApplicationCommandOptions): MethodDecoratorEx {
   return function <T>(target: Record<string, T>, key: string) {
     const applicationCommand = DApplicationCommand.create({

--- a/packages/discordx/src/decorators/decorators/Slash.ts
+++ b/packages/discordx/src/decorators/decorators/Slash.ts
@@ -6,8 +6,18 @@ import { DApplicationCommand, MetadataStorage } from "../../index.js";
 
 /**
  * Handle a slash command with a defined name
+ * ___
  *
- * @param options - Slash options
+ * [View Documentation](https://discord-ts.js.org/docs/decorators/commands/slash)
+ *
+ * @category Decorator
+ */
+export function Slash(): MethodDecoratorEx;
+
+/**
+ * Handle a slash command with a defined name
+ *
+ * @param options - Application command options
  * ___
  *
  * [View Documentation](https://discord-ts.js.org/docs/decorators/commands/slash)

--- a/packages/discordx/src/decorators/decorators/SlashChoice.ts
+++ b/packages/discordx/src/decorators/decorators/SlashChoice.ts
@@ -49,6 +49,16 @@ export function SlashChoice<T extends string, X = string | number>(
   ...choices: SlashChoiceType<T, X>[]
 ): ParameterDecoratorEx;
 
+/**
+ * The slash command option can implement autocompletion for string and number types
+ *
+ * @param choices - choices
+ * ___
+ *
+ * [View Documentation](https://discord-ts.js.org/docs/decorators/commands/slash-choice)
+ *
+ * @category Decorator
+ */
 export function SlashChoice(
   ...choices: (number | string | SlashChoiceType)[]
 ): ParameterDecoratorEx {

--- a/packages/discordx/src/decorators/decorators/SlashGroup.ts
+++ b/packages/discordx/src/decorators/decorators/SlashGroup.ts
@@ -58,8 +58,21 @@ export function SlashGroup(name: string): ClassMethodDecorator;
  */
 export function SlashGroup(name: string, root: string): ClassMethodDecorator;
 
+/**
+ * Assign a group to a method or class
+ *
+ * @param options - Group options or name
+ * @param root - Root name of group
+ * ___
+ *
+ * [View Discord.ts Documentation](https://discord-ts.js.org/docs/decorators/commands/slash-group)
+ *
+ * [View Discord Documentation](https://discord.com/developers/docs/interactions/application-commands#subcommands-and-subcommand-groups)
+ *
+ * @category Decorator
+ */
 export function SlashGroup(
-  options: SlashGroupOptions | string,
+  options: string | SlashGroupOptions,
   root?: string
 ): ClassMethodDecorator {
   return function <T>(

--- a/packages/discordx/src/decorators/decorators/SlashOption.ts
+++ b/packages/discordx/src/decorators/decorators/SlashOption.ts
@@ -19,11 +19,9 @@ import {
  *
  * @category Decorator
  */
-export function SlashOption<T extends string>(
-  options: SlashOptionOptions<VerifyName<T>>
-): ParameterDecoratorEx;
-
-export function SlashOption(options: SlashOptionOptions): ParameterDecoratorEx {
+export function SlashOption<TName extends string>(
+  options: SlashOptionOptions<VerifyName<TName>>
+): ParameterDecoratorEx {
   function getType(type: string): ApplicationCommandOptionType {
     switch (type) {
       case "STRING": {

--- a/packages/discordx/src/decorators/decorators/SlashOption.ts
+++ b/packages/discordx/src/decorators/decorators/SlashOption.ts
@@ -12,7 +12,7 @@ import {
 /**
  * Add a slash command option
  *
- * @param name - Option name
+ * @param options - Slash option options
  * ___
  *
  * [View Documentation](https://discord-ts.js.org/docs/decorators/commands/slash-option)
@@ -20,29 +20,10 @@ import {
  * @category Decorator
  */
 export function SlashOption<T extends string>(
-  name: VerifyName<T>
+  options: SlashOptionOptions<VerifyName<T>>
 ): ParameterDecoratorEx;
 
-/**
- * Add a slash command option
- *
- * @param name - Option name
- * @param options - Additional options
- * ___
- *
- * [View Documentation](https://discord-ts.js.org/docs/decorators/commands/slash-option)
- *
- * @category Decorator
- */
-export function SlashOption<T extends string>(
-  name: VerifyName<T>,
-  options?: SlashOptionOptions
-): ParameterDecoratorEx;
-
-export function SlashOption(
-  name: string,
-  options?: SlashOptionOptions
-): ParameterDecoratorEx {
+export function SlashOption(options: SlashOptionOptions): ParameterDecoratorEx {
   function getType(type: string): ApplicationCommandOptionType {
     switch (type) {
       case "STRING": {
@@ -101,7 +82,7 @@ export function SlashOption(
       maxValue: options?.maxValue,
       minLength: options?.minLength,
       minValue: options?.minValue,
-      name: name,
+      name: options.name,
       nameLocalizations: options?.nameLocalizations,
       required: options?.required,
       type: type,

--- a/packages/discordx/src/types/public/common.ts
+++ b/packages/discordx/src/types/public/common.ts
@@ -99,16 +99,18 @@ export type SlashGroupOptions = SlashGroupRoot | SlashGroupSubRoot;
  */
 export type EventOptions = {
   botIds?: string[];
+  event: DiscordEvents;
 };
 
 /**
  * Reaction options
  */
-export type ReactionOptions = {
+export type ReactionOptions<T extends string = string> = {
   aliases?: string[];
   botIds?: string[];
   description?: string;
   directMessage?: boolean;
+  emoji: NotEmpty<T>;
   guilds?: IGuild[];
   partial?: boolean;
   remove?: boolean;
@@ -120,4 +122,14 @@ export type ReactionOptions = {
 export type SlashChoiceType<T extends string = string, X = string | number> = {
   name: NotEmpty<T>;
   value?: X;
+};
+
+/**
+ * Component type
+ */
+
+export type ComponentOptions<T extends string = string> = {
+  botIds?: string[];
+  guilds?: IGuild[];
+  id?: NotEmpty<T> | RegExp;
 };

--- a/packages/discordx/src/types/public/simple command.ts
+++ b/packages/discordx/src/types/public/simple command.ts
@@ -7,21 +7,28 @@ import type {
 } from "discord.js";
 
 import type { SimpleCommandMessage } from "../../index.js";
-import type { IGuild, IPrefix } from "../index.js";
+import type { IGuild, IPrefix, NotEmpty } from "../index.js";
 
 export type ArgSplitter =
   | string
   | RegExp
   | ((command: SimpleCommandMessage) => string[]);
 
-export type SimpleCommandOptions = {
+export type SimpleCommandOptions<T extends string = string> = {
   aliases?: string[];
   argSplitter?: ArgSplitter;
   botIds?: string[];
   description?: string;
   directMessage?: boolean;
   guilds?: IGuild[];
+  name?: NotEmpty<T>;
   prefix?: IPrefix;
+};
+
+export type SimpleCommandOptionOptions<T extends string = string> = {
+  description?: string;
+  name: NotEmpty<T>;
+  type?: SimpleCommandOptionType;
 };
 
 export type SimpleOptionType =

--- a/packages/discordx/src/types/public/slash.ts
+++ b/packages/discordx/src/types/public/slash.ts
@@ -10,13 +10,14 @@ import type {
 
 import type { DApplicationCommand, IGuild } from "../../index.js";
 
-export type ApplicationCommandOptions = {
+export type ApplicationCommandOptions<TName extends string = string> = {
   botIds?: string[];
   defaultMemberPermissions?: PermissionResolvable;
   description?: string;
   descriptionLocalizations?: LocalizationMap;
   dmPermission?: boolean;
   guilds?: IGuild[];
+  name: TName;
   nameLocalizations?: LocalizationMap;
 };
 

--- a/packages/discordx/src/types/public/slash.ts
+++ b/packages/discordx/src/types/public/slash.ts
@@ -17,11 +17,11 @@ export type ApplicationCommandOptions<TName extends string = string> = {
   descriptionLocalizations?: LocalizationMap;
   dmPermission?: boolean;
   guilds?: IGuild[];
-  name: TName;
+  name?: TName;
   nameLocalizations?: LocalizationMap;
 };
 
-export type SlashOptionBase = {
+export type SlashOptionBase<TName extends string = string> = {
   autocomplete?: undefined;
   channelTypes?: undefined;
   description?: string;
@@ -30,40 +30,40 @@ export type SlashOptionBase = {
   maxValue?: undefined;
   minLength?: undefined;
   minValue?: undefined;
+  name: TName;
   nameLocalizations?: LocalizationMap;
   required?: boolean;
 };
 
-export type SlashOptionBaseOptions = SlashOptionBase & {
-  type?: Exclude<
-    ApplicationCommandOptionType,
-    | ApplicationCommandOptionType.Subcommand
-    | ApplicationCommandOptionType.SubcommandGroup
-    | ApplicationCommandOptionType.Channel
-  >;
-};
+export type SlashOptionBaseOptions<TName extends string = string> =
+  SlashOptionBase<TName> & {
+    type?: Exclude<
+      ApplicationCommandOptionType,
+      | ApplicationCommandOptionType.Subcommand
+      | ApplicationCommandOptionType.SubcommandGroup
+      | ApplicationCommandOptionType.Channel
+    >;
+  };
 
-export type SlashOptionChannelOptions = Omit<
-  SlashOptionBase,
+export type SlashOptionChannelOptions<TName extends string = string> = Omit<
+  SlashOptionBase<TName>,
   "channelTypes"
 > & {
   channelTypes?: ChannelType[];
   type: ApplicationCommandOptionType.Channel;
 };
 
-export type SlashOptionAutoCompleteOptions = Omit<
-  SlashOptionBase,
-  "autocomplete"
-> & {
-  autocomplete?: SlashAutoCompleteOption;
-  type:
-    | ApplicationCommandOptionType.String
-    | ApplicationCommandOptionType.Number
-    | ApplicationCommandOptionType.Integer;
-};
+export type SlashOptionAutoCompleteOptions<TName extends string = string> =
+  Omit<SlashOptionBase<TName>, "autocomplete"> & {
+    autocomplete?: SlashAutoCompleteOption;
+    type:
+      | ApplicationCommandOptionType.String
+      | ApplicationCommandOptionType.Number
+      | ApplicationCommandOptionType.Integer;
+  };
 
-export type SlashOptionNumberOptions = Omit<
-  SlashOptionBase,
+export type SlashOptionNumberOptions<TName extends string = string> = Omit<
+  SlashOptionBase<TName>,
   "maxValue" | "minValue" | "autocomplete"
 > & {
   autocomplete?: SlashAutoCompleteOption;
@@ -74,8 +74,8 @@ export type SlashOptionNumberOptions = Omit<
     | ApplicationCommandOptionType.Integer;
 };
 
-export type SlashOptionStringOptions = Omit<
-  SlashOptionBase,
+export type SlashOptionStringOptions<TName extends string = string> = Omit<
+  SlashOptionBase<TName>,
   "maxLength" | "minLength" | "autocomplete"
 > & {
   autocomplete?: SlashAutoCompleteOption;
@@ -84,12 +84,12 @@ export type SlashOptionStringOptions = Omit<
   type: ApplicationCommandOptionType.String;
 };
 
-export type SlashOptionOptions =
-  | SlashOptionBaseOptions
-  | SlashOptionChannelOptions
-  | SlashOptionNumberOptions
-  | SlashOptionStringOptions
-  | SlashOptionAutoCompleteOptions;
+export type SlashOptionOptions<TName extends string = string> =
+  | SlashOptionBaseOptions<TName>
+  | SlashOptionChannelOptions<TName>
+  | SlashOptionNumberOptions<TName>
+  | SlashOptionStringOptions<TName>
+  | SlashOptionAutoCompleteOptions<TName>;
 
 export type SlashAutoCompleteOption =
   | undefined

--- a/packages/discordx/tests/command.test.ts
+++ b/packages/discordx/tests/command.test.ts
@@ -19,17 +19,17 @@ type Data = { passed: boolean };
   return next();
 })
 export class Example {
-  @SimpleCommand("add", {
+  @SimpleCommand({
     aliases: ["add1", "add2"],
     argSplitter: "~",
     description: "Addition",
   })
   add(
-    @SimpleCommandOption("x", { description: "x value" })
+    @SimpleCommandOption({ description: "x value", name: "x" })
     x: number,
-    @SimpleCommandOption("op", { description: "operation value" })
+    @SimpleCommandOption({ description: "operation value", name: "op" })
     op: string,
-    @SimpleCommandOption("y", { description: "y value" })
+    @SimpleCommandOption({ description: "y value", name: "y" })
     y: number,
     command: SimpleCommandMessage,
     client: Client,
@@ -41,13 +41,13 @@ export class Example {
     return ["!add", [op, x + y], command, data.passed];
   }
 
-  @SimpleCommand("sub", {
+  @SimpleCommand({
     argSplitter: "|",
   })
   sub(
-    @SimpleCommandOption("x", { description: "x value" })
+    @SimpleCommandOption({ description: "x value", name: "x" })
     x: string,
-    @SimpleCommandOption("y", { description: "y value" })
+    @SimpleCommandOption({ description: "y value", name: "y" })
     y: string,
     command: SimpleCommandMessage,
     client: Client,
@@ -56,7 +56,7 @@ export class Example {
     return ["!add", [x, y], command, data.passed];
   }
 
-  @SimpleCommand("add plus")
+  @SimpleCommand({ name: "add plus" })
   addExtend(
     command: SimpleCommandMessage,
     client: Client,
@@ -65,9 +65,9 @@ export class Example {
     return ["!add plus", [], command, data.passed];
   }
 
-  @SimpleCommand("add plus second")
+  @SimpleCommand({ name: "add plus second" })
   addExtendSecond(
-    @SimpleCommandOption("arg") arg: string,
+    @SimpleCommandOption({ name: "arg" }) arg: string,
     command: SimpleCommandMessage,
     client: Client,
     data: Data
@@ -75,15 +75,15 @@ export class Example {
     return ["!add plus second", [arg], command, data.passed];
   }
 
-  @SimpleCommand("ban", {
+  @SimpleCommand({
     argSplitter:
       /\s\"|\s'|"|'|\s(?=(?:"[^"]*"|[^"])*$)(?=(?:'[^']*'|[^'])*$)/gm,
   })
   ban(
-    @SimpleCommandOption("id") id: number,
-    @SimpleCommandOption("time") time: number,
-    @SimpleCommandOption("reason") reason: string,
-    @SimpleCommandOption("type") type: string,
+    @SimpleCommandOption({ name: "id" }) id: number,
+    @SimpleCommandOption({ name: "time" }) time: number,
+    @SimpleCommandOption({ name: "reason" }) reason: string,
+    @SimpleCommandOption({ name: "type" }) type: string,
     command: SimpleCommandMessage,
     client: Client,
     data: Data
@@ -91,7 +91,7 @@ export class Example {
     return ["!ban", [id, time, reason, type], command, data.passed];
   }
 
-  @SimpleCommand("findSource")
+  @SimpleCommand()
   findSource(
     command: SimpleCommandMessage,
     client: Client,

--- a/packages/discordx/tests/create-on-events.test.ts
+++ b/packages/discordx/tests/create-on-events.test.ts
@@ -25,23 +25,23 @@ const guard2: GuardFunction = async ([]: [string], client, next, data) => {
 
 @Discord()
 export class Example {
-  @On("messageCreate")
-  private onMessage([message]: [string]) {
+  @On()
+  messageCreate([message]: [string]): string {
     return message;
   }
 
-  @On("messageCreate")
-  private onMessage2([message]: [string]) {
+  @On({ event: "messageCreate" })
+  messageCreate2([message]: [string]): string {
     return message;
   }
 
-  @On("messageDelete")
+  @On()
   @Guard(guard1, guard2)
-  private onMessageDelete(
+  messageDelete(
     []: [string],
     client: Client,
     guardParams: { message: string }
-  ) {
+  ): void {
     guardParams.message += "3";
   }
 }

--- a/packages/discordx/tests/interactions/button/button.test.ts
+++ b/packages/discordx/tests/interactions/button/button.test.ts
@@ -10,7 +10,7 @@ import { FakeInteraction, InteractionType } from "../../interaction.js";
 
 @Discord()
 export class Example {
-  @ButtonComponent("hello")
+  @ButtonComponent({ id: "hello" })
   @Guard((params, client, next, data) => {
     data.passed = true;
     return next();
@@ -23,7 +23,7 @@ export class Example {
     return [":wave:", data.passed];
   }
 
-  @ButtonComponent("hello")
+  @ButtonComponent({ id: "hello" })
   handler2(): unknown {
     return [":shake:", undefined];
   }

--- a/packages/discordx/tests/interactions/slash/choice.test.ts
+++ b/packages/discordx/tests/interactions/slash/choice.test.ts
@@ -42,7 +42,7 @@ export class Example {
         value: TextChoices["Good Bye"],
       }
     )
-    @SlashOption("choice")
+    @SlashOption({ name: "choice" })
     choice: TextChoices,
     interaction: CommandInteraction
   ): unknown {
@@ -53,7 +53,7 @@ export class Example {
   number(
     @SlashChoice<string, number>({ name: "1", value: 1 })
     @SlashChoice(2, 3, 4)
-    @SlashOption("choice")
+    @SlashOption({ name: "choice" })
     choice: number,
     interaction: CommandInteraction
   ): unknown {
@@ -64,7 +64,7 @@ export class Example {
   string(
     @SlashChoice({ name: "A", value: "A" })
     @SlashChoice("B", "C", "D")
-    @SlashOption("choice")
+    @SlashOption({ name: "choice" })
     choice: string,
     interaction: CommandInteraction
   ): unknown {

--- a/packages/discordx/tests/slash.test.ts
+++ b/packages/discordx/tests/slash.test.ts
@@ -51,20 +51,22 @@ enum TextChoices {
   return next();
 })
 export class Example {
-  @Slash("add", { description: "Addition" })
+  @Slash({ description: "Addition" })
   @SlashGroup("maths", "testing")
   add(
-    @SlashOption("x", {
+    @SlashOption({
       description: "x value",
       maxValue: 10,
       minValue: 1,
+      name: "x",
       type: ApplicationCommandOptionType.Number,
     })
     x: number,
-    @SlashOption("y", {
+    @SlashOption({
       description: "y value",
       maxValue: 10,
       minValue: 1,
+      name: "y",
       type: ApplicationCommandOptionType.Number,
     })
     y: number,
@@ -75,12 +77,12 @@ export class Example {
     return ["/testing maths add", x + y, interaction, data.passed];
   }
 
-  @Slash("multiply", { description: "Multiply" })
+  @Slash({ description: "Multiply" })
   @SlashGroup("maths", "testing")
   multiply(
-    @SlashOption("x", { description: "x value" })
+    @SlashOption({ description: "x value", name: "x" })
     x: number,
-    @SlashOption("y", { description: "y value" })
+    @SlashOption({ description: "y value", name: "y" })
     y: number,
     interaction: CommandInteraction,
     client: Client,
@@ -89,7 +91,7 @@ export class Example {
     return ["/testing maths multiply", x * y, interaction, data.passed];
   }
 
-  @Slash("hello")
+  @Slash()
   @SlashGroup("text", "testing")
   hello(
     @SlashChoice(
@@ -102,7 +104,7 @@ export class Example {
         value: TextChoices["Good Bye"],
       }
     )
-    @SlashOption("text")
+    @SlashOption({ name: "text" })
     text: TextChoices,
     interaction: CommandInteraction,
     client: Client,
@@ -111,12 +113,12 @@ export class Example {
     return ["/testing text hello", text, interaction, data.passed];
   }
 
-  @Slash("hello")
+  @Slash({ name: "hello" })
   @SlashGroup("testing")
   root(
-    @SlashOption("text")
+    @SlashOption({ name: "text" })
     text: string,
-    @SlashOption("text2", { required: false })
+    @SlashOption({ name: "text2", required: false })
     text2: string,
     interaction: CommandInteraction,
     client: Client,
@@ -140,12 +142,12 @@ export class Example {
   return next();
 })
 export class Example2 {
-  @Slash("add", { description: "Addition" })
+  @Slash({ description: "Addition" })
   @SlashGroup("line", "group-test-without-description")
   add(
-    @SlashOption("x", { description: "x value" })
+    @SlashOption({ description: "x value", name: "x" })
     x: number,
-    @SlashOption("y", { description: "y value" })
+    @SlashOption({ description: "y value", name: "y" })
     y: number,
     interaction: CommandInteraction,
     client: Client,
@@ -162,9 +164,9 @@ export class Example2 {
   return next();
 })
 export class Example3 {
-  @Slash("hello")
-  add(
-    @SlashOption("text", { required: false })
+  @Slash()
+  hello(
+    @SlashOption({ name: "text", required: false })
     text: string,
     interaction: CommandInteraction,
     client: Client,
@@ -173,39 +175,45 @@ export class Example3 {
     return ["/hello", text, interaction, data.passed];
   }
 
-  @Slash("inference")
+  @Slash()
   inference(
-    @SlashOption("text")
+    @SlashOption({ name: "text" })
     text: string,
 
-    @SlashOption("bool")
+    @SlashOption({ name: "bool" })
     bool: boolean,
 
-    @SlashOption("nb")
+    @SlashOption({ name: "nb" })
     nb: number,
 
-    @SlashOption("channel", { type: ApplicationCommandOptionType.Channel })
+    @SlashOption({
+      name: "channel",
+      type: ApplicationCommandOptionType.Channel,
+    })
     channel: Channel,
 
-    @SlashOption("text-channel", {
+    @SlashOption({
+      name: "text-channel",
       required: false,
       type: ApplicationCommandOptionType.Channel,
     })
     textChannel: TextChannel,
 
-    @SlashOption("voice-channel", {
+    @SlashOption({
+      name: "voice-channel",
       required: false,
       type: ApplicationCommandOptionType.Channel,
     })
     voiceChannel: VoiceChannel,
 
-    @SlashOption("user", { required: false })
+    @SlashOption({ name: "user", required: false })
     clientUser: User,
 
-    @SlashOption("role", { required: false })
+    @SlashOption({ name: "role", required: false })
     role: Role,
 
-    @SlashOption("user-or-role", {
+    @SlashOption({
+      name: "user-or-role",
       required: false,
       type: ApplicationCommandOptionType.Mentionable,
     })


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Replace all plain arguments with object for decorators

### Before

```ts
@Slash("hello")
```

### After

```ts
@Slash({ name: "hello" })
```

### Decorators refactored

- ButtonComponent
- ContextMenu
- ModalComponent
- SelectMenuComponent
- Slash
- SlashOption
- SimpleCommand
- SimpleCommandOption

## Package

discordx