### PR TITLE
feat(discordx): slash command alias

### DIFF
--- a/docs/docs/discordx/decorators/command/slash.md
+++ b/docs/docs/discordx/decorators/command/slash.md
@@ -7,10 +7,12 @@ Discord has it's own command system now, you can simply declare commands and use
 ## Signature
 
 ```ts
-Slash(options: ApplicationCommandOptions)
+Slash(options: ApplicationCommandOptions<VerifyName<T>, NotEmpty<TD>> | SlashCommandBuilder)
 ```
 
-## Example
+## Examples
+
+### Simple usage
 
 ```ts
 import { Discord, Slash } from "discordx";
@@ -18,6 +20,65 @@ import { Discord, Slash } from "discordx";
 @Discord()
 class Example {
   @Slash({ description: "hello", name: "hello" })
+  hello(interaction: CommandInteraction) {
+    // ...
+  }
+}
+```
+
+### Builders
+
+Discord.js's SlashCommandBuilder can also be used in the decorator to define the command.
+
+```ts
+import { SlashCommandBuilder } from "discord.js";
+import { Discord, Slash } from "discordx";
+
+@Discord()
+class Example {
+  @Slash(
+    new SlashCommandBuilder().setName("hello").setDescription("Say hello!"),
+  )
+  hello(interaction: CommandInteraction) {
+    // ...
+  }
+}
+```
+
+### Aliases
+
+Slash commands can also have aliases using the SlashWithAliases decorator,
+both with the default configuration and builder.
+
+> In these examples, three slash commands will be created: `/hello`, `/hey` and `/hi`.
+
+#### Default configuration
+
+```ts
+import { Discord, SlashWithAliases } from "discordx";
+
+@Discord()
+class Example {
+  @SlashWithAliases({ description: "hello", name: "hello" }, ["hey", "hi"])
+  hello(interaction: CommandInteraction) {
+    // ...
+  }
+}
+```
+
+#### Builder configuration
+
+```ts
+import { SlashCommandBuilder } from "discord.js";
+import { Discord, SlashWithAliases } from "discordx";
+
+const command = new SlashCommandBuilder()
+  .setName("hello")
+  .setDescription("Say hello!");
+
+@Discord()
+class Example {
+  @SlashWithAliases(command, ["hey", "hi"])
   hello(interaction: CommandInteraction) {
     // ...
   }

--- a/packages/discordx/src/decorators/decorators/SlashWithAliases.ts
+++ b/packages/discordx/src/decorators/decorators/SlashWithAliases.ts
@@ -1,0 +1,85 @@
+/*
+ * -------------------------------------------------------------------------------------------------------
+ * Copyright (c) Vijay Meena <vijayymmeena@gmail.com> (https://github.com/vijayymmeena). All rights reserved.
+ * Licensed under the Apache License. See License.txt in the project root for license information.
+ * -------------------------------------------------------------------------------------------------------
+ */
+import type { MethodDecoratorEx } from "@discordx/internal";
+import { SlashCommandBuilder } from "discord.js";
+
+import type { ApplicationCommandOptions } from "../../index.js";
+import { Slash } from "../../index.js";
+
+/**
+ * Handle a slash command with a defined name and aliases
+ *
+ * @param command - Application command options
+ * @param aliases - Command aliases
+ * ___
+ *
+ * [View Documentation](https://discordx.js.org/docs/discordx/decorators/command/slash)
+ *
+ * @category Decorator
+ */
+export function SlashWithAliases(
+  command: SlashCommandBuilder,
+  aliases: Lowercase<string>[],
+): MethodDecoratorEx;
+
+/**
+ * Handle a slash command with a defined name and aliases
+ *
+ * @param command - Application command options
+ * @param aliases - Command aliases
+ * ___
+ *
+ * [View Documentation](https://discordx.js.org/docs/discordx/decorators/command/slash)
+ *
+ * @category Decorator
+ */
+export function SlashWithAliases<T extends Lowercase<string>>(
+  command: ApplicationCommandOptions<T, string>,
+  aliases: T[],
+): MethodDecoratorEx;
+
+/**
+ * Handle a slash command with a defined name and aliases
+ *
+ * @param command - Application command options
+ * @param aliases - Command aliases
+ * ___
+ *
+ * [View Documentation](https://discordx.js.org/docs/discordx/decorators/command/slash)
+ *
+ * @category Decorator
+ */
+export function SlashWithAliases<T extends Lowercase<string>>(
+  command: ApplicationCommandOptions<T, string> | SlashCommandBuilder,
+  aliases: T[],
+) {
+  return function (
+    target: any,
+    propertyKey: string,
+    descriptor: PropertyDescriptor,
+  ) {
+    const allNames = [command.name, ...aliases];
+
+    for (const name of allNames) {
+      if (command instanceof SlashCommandBuilder) {
+        if (name) {
+          command.setName(name);
+        }
+
+        Slash(command)(target, propertyKey, descriptor);
+
+        continue;
+      }
+
+      Slash({ ...command, name: name as Lowercase<string> })(
+        target,
+        propertyKey,
+        descriptor,
+      );
+    }
+  };
+}

--- a/packages/discordx/src/decorators/decorators/index.ts
+++ b/packages/discordx/src/decorators/decorators/index.ts
@@ -21,3 +21,4 @@ export * from "./Slash.js";
 export * from "./SlashChoice.js";
 export * from "./SlashGroup.js";
 export * from "./SlashOption.js";
+export * from "./SlashWithAliases.js";


### PR DESCRIPTION
**Please describe the changes this PR makes:**

This PR enables the use of aliases in slash commands.

I added the `aliases` as a second optional parameter so that it works both with `ApplicationCommandOptions` and `SlashCommandBuilder`