### PR TITLE
fix(pagination): allow null for label or emoji in button config

### DIFF
--- a/packages/pagination/CHANGELOG.md
+++ b/packages/pagination/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- [`80c6262`](https://github.com/discordx-ts/discordx/commit/80c6262a77cf9379d2dcef188288c76a589f21c3) Thanks [@Jarva](https://github.com/Jarva)! - preserve null values for emoji and label options on button components
+- Thanks [@Jarva](https://github.com/Jarva)! - preserve null values for emoji and label options on button components
 
 ## 4.4.0
 

--- a/packages/pagination/CHANGELOG.md
+++ b/packages/pagination/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @discordx/pagination
 
+## 4.4.1
+
+### Patch Changes
+
+- [`80c6262`](https://github.com/discordx-ts/discordx/commit/80c6262a77cf9379d2dcef188288c76a589f21c3) Thanks [@Jarva](https://github.com/Jarva)! - preserve null values for emoji and label options on button components
+
 ## 4.4.0
 
 ### Minor Changes

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discordx/pagination",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "private": false,
   "description": "Library for creating pagination messages in Discord bots",
   "keywords": [

--- a/packages/pagination/src/pagination/builder.ts
+++ b/packages/pagination/src/pagination/builder.ts
@@ -212,18 +212,26 @@ export class PaginationBuilder {
       .setStyle(userConfig?.style ?? config.defaults.style)
       .setDisabled(config.disabled);
 
-    const label = userConfig?.label ?? config.defaults.label;
+    const label =
+      userConfig?.label !== undefined
+        ? userConfig.label
+        : config.defaults.label;
+
+    const emoji =
+      userConfig?.emoji !== undefined
+        ? userConfig.emoji
+        : config.defaults.emoji;
+
+    if (!label && !emoji) {
+      throw Error("Pagination buttons must include either an emoji or a label");
+    }
+
     if (label) {
       button.setLabel(label);
     }
 
-    const emoji = userConfig?.emoji ?? config.defaults.emoji;
     if (emoji) {
       button.setEmoji(emoji);
-    }
-
-    if (!label && !emoji) {
-      throw Error("Pagination buttons must include either an emoji or a label");
     }
 
     return button;

--- a/packages/pagination/src/pagination/builder.ts
+++ b/packages/pagination/src/pagination/builder.ts
@@ -13,13 +13,13 @@ import {
 
 import { createPagination } from "../utils/index.js";
 import {
+  type ButtonOptions,
   defaultIds,
   defaultPerPageItem,
-  SelectMenuPageId,
-  type ButtonOptions,
   type IPaginate,
   type PaginationItem,
   type PaginationOptions,
+  SelectMenuPageId,
 } from "./index.js";
 
 export class PaginationBuilder {


### PR DESCRIPTION
`emoji` and `label` are intended to be nullable, allowing users to explicitly disable them. However, the use of the nullish coalescing operator (??) caused null values to be treated as missing and replaced with the configured defaults.

This change preserves null values and only falls back to defaults when the value is undefined.